### PR TITLE
feat: add development artifact remover

### DIFF
--- a/src/ar_infra/application/use_cases/generate_project_use_case.py
+++ b/src/ar_infra/application/use_cases/generate_project_use_case.py
@@ -10,6 +10,9 @@ from src.ar_infra.domain.value_objects.package_name import PackageName
 from src.ar_infra.infrastructure.gradle import GradleWriter
 from src.ar_infra.infrastructure.processor import GitRepositoryInitializer, PackageRenamer
 from src.ar_infra.infrastructure.template import FeatureManager, GitHubTemplateFetcher
+from src.ar_infra.infrastructure.template.development_artifact_remover import (
+    DevelopmentArtifactCleaner,
+)
 from src.ar_infra.infrastructure.template.project_signature import (
     InfraGeneratedAnnotationWriter,
     ProjectSignature,
@@ -28,6 +31,7 @@ class GenerateProjectUseCase:
         package_renamer: PackageRenamer,
         git_initializer: GitRepositoryInitializer | None = None,
         annotation_writer: InfraGeneratedAnnotationWriter | None = None,
+        artifact_cleaner: DevelopmentArtifactCleaner | None = None,
     ) -> None:
         self._template_fetcher = template_fetcher
         self._feature_manager = feature_manager
@@ -35,6 +39,7 @@ class GenerateProjectUseCase:
         self._package_renamer = package_renamer
         self._git_initializer = git_initializer or GitRepositoryInitializer()
         self._annotation_writer = annotation_writer or InfraGeneratedAnnotationWriter()
+        self._artifact_cleaner = artifact_cleaner
 
     def execute(self, input_dto: GenerateProjectInput) -> GenerateProjectOutput:
         """Execute project generation workflow."""
@@ -46,6 +51,7 @@ class GenerateProjectUseCase:
             self._rename_packages(input_dto, placeholder_package)
             self._update_settings_gradle(input_dto)
             signature = self._update_infra_generated_annotation(input_dto)
+            self._clean_development_artifacts(input_dto)
             self._initialize_git_repository(input_dto)
 
             return GenerateProjectOutput(
@@ -147,6 +153,22 @@ class GenerateProjectUseCase:
         for annotation_file in java_dir.rglob("InfraGenerated.java"):
             return annotation_file
         return None
+
+    def _clean_development_artifacts(self, input_dto: GenerateProjectInput) -> None:
+        """Remove development artifacts from the generated project."""
+        try:
+            cleaner = self._artifact_cleaner or DevelopmentArtifactCleaner(input_dto.destination)
+
+            if self._artifact_cleaner is None:
+                cleaner = DevelopmentArtifactCleaner(input_dto.destination)
+
+            cleaner.clean()
+
+            cleaner.clean_empty_parent_directories(".github/dependabot.yml")
+            cleaner.clean_empty_parent_directories(".github/CODEOWNERS")
+
+        except Exception as exc:
+            raise GenerateProjectError("Failed to clean development artifacts") from exc
 
     def _initialize_git_repository(self, input_dto: GenerateProjectInput) -> None:
         self._git_initializer.initialize_repository(

--- a/src/ar_infra/infrastructure/template/development_artifact_remover.py
+++ b/src/ar_infra/infrastructure/template/development_artifact_remover.py
@@ -1,0 +1,203 @@
+"""Module for removing development artifacts from generated projects."""
+
+import logging
+from pathlib import Path
+from typing import Final
+
+
+logger = logging.getLogger(__name__)
+
+
+class DevelopmentArtifactCleaner:
+    """
+    Removes development-specific files and directories from generated projects.
+
+    This class safely removes files and directories that were used during
+    infrastructure development but should not be included in the generated
+    project output.
+
+    Security considerations:
+    - Validates all paths to prevent directory traversal attacks
+    - Only operates within the specified project root
+    - Uses Path.resolve() to normalize and validate paths
+    """
+
+    DEFAULT_ARTIFACTS: Final[list[str]] = [
+        ".github/dependabot.yml",
+        ".github/CODEOWNERS",
+        "ar-infra-logo.png",
+        "code_of_conduct.md",
+        "readme.md",
+        "security.md",
+        "contributing.md",
+        "licence",
+    ]
+
+    def __init__(self, project_root: Path) -> None:
+        """
+        Initialize the cleaner with a project root directory.
+
+        Args:
+            project_root: The root directory of the generated project.
+                         All operations are constrained to this directory.
+
+        Raises:
+            ValueError: If project_root doesn't exist or isn't a directory.
+        """
+        if not project_root.exists():
+            raise ValueError(f"Project root does not exist: {project_root}")
+
+        if not project_root.is_dir():
+            raise ValueError(f"Project root is not a directory: {project_root}")
+
+        self._project_root = project_root.resolve()
+        logger.info("Initialized DevelopmentArtifactCleaner for: %s", self._project_root)
+
+    def _validate_path(self, target_path: Path) -> Path:
+        """
+        Validate that a path is within the project root.
+
+        Args:
+            target_path: The path to validate.
+
+        Returns:
+            The resolved absolute path.
+
+        Raises:
+            ValueError: If the path escapes the project root.
+        """
+        resolved = target_path.resolve()
+
+        try:
+            resolved.relative_to(self._project_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"Path {target_path} is outside project root {self._project_root}"
+            ) from exc
+
+        return resolved
+
+    def remove_artifact(self, relative_path: str) -> bool:
+        """
+        Remove a single file or directory artifact.
+
+        Args:
+            relative_path: Path relative to project root (e.g., "readme.md").
+
+        Returns:
+            True if the artifact was removed, False if it didn't exist.
+
+        Raises:
+            ValueError: If the path is invalid or outside project root.
+            OSError: If removal fails due to permissions or other OS errors.
+        """
+        target = self._project_root / relative_path
+        validated_target = self._validate_path(target)
+
+        if not validated_target.exists():
+            logger.debug("Artifact does not exist, skipping: %s", relative_path)
+            return False
+
+        try:
+            if validated_target.is_file() or validated_target.is_symlink():
+                validated_target.unlink()
+                logger.info("Removed file: %s", relative_path)
+                removed = True
+            elif validated_target.is_dir():
+                self._remove_directory_recursive(validated_target)
+                logger.info("Removed directory: %s", relative_path)
+                removed = True
+            else:
+                logger.warning("Unknown artifact type, skipping: %s", relative_path)
+                removed = False
+        except OSError:
+            logger.exception("Failed to remove %s", relative_path)
+            raise
+
+        return removed
+
+    def _remove_directory_recursive(self, directory: Path) -> None:
+        """
+        Recursively remove a directory and all its contents.
+
+        Args:
+            directory: The directory to remove (must be validated).
+
+        Raises:
+            OSError: If removal fails.
+        """
+        for child in directory.iterdir():
+            if child.is_file() or child.is_symlink():
+                child.unlink()
+            elif child.is_dir():
+                self._remove_directory_recursive(child)
+
+        directory.rmdir()
+
+    def clean(self, artifacts: list[str] | None = None) -> int:
+        """
+        Remove multiple development artifacts from the project.
+
+        Args:
+            artifacts: List of relative paths to remove.
+                      If None, uses DEFAULT_ARTIFACTS.
+
+        Returns:
+            Number of artifacts successfully removed.
+
+        Raises:
+            ValueError: If any path is invalid.
+            OSError: If removal fails.
+        """
+        artifacts_to_remove = artifacts if artifacts is not None else self.DEFAULT_ARTIFACTS
+        removed_count = 0
+
+        logger.info("Starting cleanup of %d artifacts", len(artifacts_to_remove))
+
+        for artifact in artifacts_to_remove:
+            if self.remove_artifact(artifact):
+                removed_count += 1
+
+        logger.info(
+            "Cleanup complete. Removed %d/%d artifacts", removed_count, len(artifacts_to_remove)
+        )
+
+        return removed_count
+
+    def clean_empty_parent_directories(self, relative_path: str) -> int:
+        """
+        Remove empty parent directories after artifact removal.
+
+        Useful for cleaning up empty .github directories after removing all files.
+
+        Args:
+            relative_path: Path whose parent directories to check.
+
+        Returns:
+            Number of empty directories removed.
+
+        Raises:
+            ValueError: If the path is invalid.
+        """
+        target = self._project_root / relative_path
+        validated_target = self._validate_path(target)
+
+        removed_count = 0
+        current = validated_target.parent
+
+        while current != self._project_root:
+            try:
+                if current.exists() and current.is_dir() and not any(current.iterdir()):
+                    current.rmdir()
+                    logger.info(
+                        "Removed empty directory: %s", current.relative_to(self._project_root)
+                    )
+                    removed_count += 1
+                    current = current.parent
+                else:
+                    break
+            except OSError as exc:
+                logger.debug("Could not remove directory %s: %s", current, exc)
+                break
+
+        return removed_count

--- a/src/ar_infra/infrastructure/template/facadeit_handler.py
+++ b/src/ar_infra/infrastructure/template/facadeit_handler.py
@@ -38,6 +38,9 @@ class FacadeITHandler:
         lines = facade_path.read_text(encoding="utf-8").splitlines()
         filtered = self._remove_disabled_feature_lines(lines, disabled_tokens)
 
+        if not enabled_features:
+            filtered = self._remove_empty_before_all(filtered)
+
         facade_path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
 
     @staticmethod
@@ -61,5 +64,33 @@ class FacadeITHandler:
             if any(token in stripped for token in disabled_tokens):
                 continue
             result.append(line)
+
+        return result
+
+    @staticmethod
+    def _remove_empty_before_all(lines: list[str]) -> list[str]:
+        result: list[str] = []
+        i = 0
+
+        while i < len(lines):
+            line = lines[i].strip()
+
+            if line == "@BeforeAll":
+                # Skip until the closing brace of the method
+                i += 1
+                brace_depth = 0
+                while i < len(lines):
+                    if "{" in lines[i]:
+                        brace_depth += 1
+                    if "}" in lines[i]:
+                        brace_depth -= 1
+                        if brace_depth <= 0:
+                            i += 1
+                            break
+                    i += 1
+                continue
+
+            result.append(lines[i])
+            i += 1
 
         return result

--- a/src/ar_infra/infrastructure/template/project_signature.py
+++ b/src/ar_infra/infrastructure/template/project_signature.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from src.ar_infra.domain.value_objects.artifact_id import ArtifactId
 from src.ar_infra.domain.value_objects.group_id import GroupId
 from src.ar_infra.domain.value_objects.version import Version
+from src.ar_infra.properties import CLI_VERSION
 
 
 @dataclass(frozen=True)
@@ -25,7 +26,7 @@ class ProjectSignature:
         group_id: GroupId,
         artifact_id: ArtifactId,
         version: Version,
-        cli_version: str = "1.0.0",
+        cli_version: str = CLI_VERSION,
     ) -> "ProjectSignature":
         project_hash = cls._compute_project_hash(group_id, artifact_id, version)
         signature = f"ar-infra-cli:{project_hash}"

--- a/tests/unit/application/test_generate_project_use_case.py
+++ b/tests/unit/application/test_generate_project_use_case.py
@@ -1,7 +1,7 @@
 """Tests for GenerateProjectUseCase."""
 
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -25,6 +25,10 @@ def mock_bot_env(monkeypatch):
 def use_case(template_fetcher, feature_manager, gradle_writer, package_renamer):
     fake_git_initializer = Mock()
     fake_annotation_writer = Mock()
+    fake_artifact_cleaner = Mock()
+    fake_artifact_cleaner.clean.return_value = 8
+    fake_artifact_cleaner.clean_empty_parent_directories.return_value = 1
+
     return GenerateProjectUseCase(
         template_fetcher=template_fetcher,
         feature_manager=feature_manager,
@@ -32,6 +36,7 @@ def use_case(template_fetcher, feature_manager, gradle_writer, package_renamer):
         package_renamer=package_renamer,
         git_initializer=fake_git_initializer,
         annotation_writer=fake_annotation_writer,
+        artifact_cleaner=fake_artifact_cleaner,
     )
 
 
@@ -243,3 +248,239 @@ class TestGenerateProjectUseCase:
         result = use_case.execute(valid_input)
 
         assert result.success is False
+
+    def test_artifact_cleaner_handles_errors(
+        self,
+        use_case: GenerateProjectUseCase,
+        valid_input: GenerateProjectInput,
+    ) -> None:
+        """Test that cleaner failures are wrapped in GenerateProjectError."""
+        use_case._artifact_cleaner.clean.side_effect = OSError("Permission denied")
+
+        result = use_case.execute(valid_input)
+
+        assert result.success is False
+        assert "Failed to clean development artifacts" in result.message
+
+    def test_artifact_cleaner_called_before_git_init(
+        self,
+        use_case: GenerateProjectUseCase,
+        valid_input: GenerateProjectInput,
+    ) -> None:
+        """Test that artifact cleaning happens before git initialization."""
+        call_order = []
+        use_case._artifact_cleaner.clean.side_effect = (
+            lambda *args: call_order.append("cleaner") or 8
+        )
+        use_case._git_initializer.initialize_repository.side_effect = (
+            lambda *args, **kwargs: call_order.append("git")
+        )
+
+        use_case.execute(valid_input)
+
+        assert call_order == ["cleaner", "git"]
+
+
+class TestArtifactCleanerIntegration:
+    """Integration tests with real artifact cleaner."""
+
+    @pytest.fixture
+    def template_fetcher_with_artifacts(self, tmp_path: Path) -> Mock:
+        """Template fetcher that creates development artifacts."""
+        fetcher = Mock()
+
+        def create_template_with_artifacts(url, destination, use_cache=False):
+            destination.mkdir(parents=True, exist_ok=True)
+
+            settings_file = destination / "settings.gradle"
+            settings_file.write_text("rootProject.name = 'arinfra'\n", encoding="utf-8")
+
+            build_gradle = destination / "build.gradle"
+            build_gradle.write_text("group = 'com.example'\nversion = '0.0.1'\n", encoding="utf-8")
+
+            github_dir = destination / ".github"
+            github_dir.mkdir()
+            (github_dir / "dependabot.yml").write_text("version: 2")
+            (github_dir / "CODEOWNERS").write_text("* @owner")
+            (destination / "readme.md").write_text("# README")
+            (destination / "licence").write_text("MIT License")
+            (destination / "contributing.md").write_text("# Contributing")
+            (destination / "security.md").write_text("# Security")
+            (destination / "code_of_conduct.md").write_text("# Code of Conduct")
+            (destination / "ar-infra-logo.png").write_bytes(b"fake image")
+
+            return "com.example.arinfra"
+
+        fetcher.fetch.side_effect = create_template_with_artifacts
+        return fetcher
+
+    @pytest.fixture
+    def feature_manager_simple(self) -> Mock:
+        """Simple feature manager for integration tests."""
+        manager = Mock()
+        manager.get_feature_dependencies.return_value = []
+        return manager
+
+    @pytest.fixture
+    def gradle_writer_simple(self) -> Mock:
+        """Simple gradle writer for integration tests."""
+        return Mock()
+
+    @pytest.fixture
+    def package_renamer_simple(self) -> Mock:
+        """Simple package renamer for integration tests."""
+        return Mock()
+
+    def test_development_artifacts_are_removed_end_to_end(
+        self,
+        template_fetcher_with_artifacts: Mock,
+        feature_manager_simple: Mock,
+        gradle_writer_simple: Mock,
+        package_renamer_simple: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that development artifacts are actually removed from generated project."""
+        fake_git_initializer = Mock()
+        fake_annotation_writer = Mock()
+
+        # Create use case WITHOUT artifact cleaner (will create real one)
+        use_case = GenerateProjectUseCase(
+            template_fetcher=template_fetcher_with_artifacts,
+            feature_manager=feature_manager_simple,
+            gradle_writer=gradle_writer_simple,
+            package_renamer=package_renamer_simple,
+            git_initializer=fake_git_initializer,
+            annotation_writer=fake_annotation_writer,
+            artifact_cleaner=None,  # Let it create a real cleaner
+        )
+
+        input_dto = GenerateProjectInput(
+            group_id=GroupId("dev.razafindratelo"),
+            artifact_id=ArtifactId("backend-api"),
+            version=Version("1.0.0"),
+            destination=tmp_path / "my-project",
+            enabled_features=set(),
+            template_url="https://github.com/Abega1642/ar-infra-template.git",
+            use_template_cache=False,
+        )
+
+        result = use_case.execute(input_dto)
+
+        assert result.success is True
+
+        project_path = input_dto.destination
+        assert not (project_path / ".github" / "dependabot.yml").exists()
+        assert not (project_path / ".github" / "CODEOWNERS").exists()
+        assert not (project_path / ".github").exists()  # Empty dir removed
+        assert not (project_path / "readme.md").exists()
+        assert not (project_path / "licence").exists()
+        assert not (project_path / "contributing.md").exists()
+        assert not (project_path / "security.md").exists()
+        assert not (project_path / "code_of_conduct.md").exists()
+        assert not (project_path / "ar-infra-logo.png").exists()
+
+        assert (project_path / "build.gradle").exists()
+        assert (project_path / "settings.gradle").exists()
+
+    def test_partial_artifact_removal_succeeds(
+        self,
+        feature_manager_simple: Mock,
+        gradle_writer_simple: Mock,
+        package_renamer_simple: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that generation succeeds even if some artifacts don't exist."""
+        fetcher = Mock()
+
+        def create_partial_template(url, destination, use_cache=False):
+            destination.mkdir(parents=True, exist_ok=True)
+            (destination / "build.gradle").write_text("group = 'com.example'\n", encoding="utf-8")
+            (destination / "settings.gradle").write_text(
+                "rootProject.name = 'app'\n", encoding="utf-8"
+            )
+            (destination / "readme.md").write_text("# README")
+            (destination / "licence").write_text("MIT")
+            return "com.example.arinfra"
+
+        fetcher.fetch.side_effect = create_partial_template
+
+        fake_git_initializer = Mock()
+        fake_annotation_writer = Mock()
+
+        use_case = GenerateProjectUseCase(
+            template_fetcher=fetcher,
+            feature_manager=feature_manager_simple,
+            gradle_writer=gradle_writer_simple,
+            package_renamer=package_renamer_simple,
+            git_initializer=fake_git_initializer,
+            annotation_writer=fake_annotation_writer,
+            artifact_cleaner=None,
+        )
+
+        input_dto = GenerateProjectInput(
+            group_id=GroupId("dev.razafindratelo"),
+            artifact_id=ArtifactId("backend-api"),
+            version=Version("1.0.0"),
+            destination=tmp_path / "my-project",
+            enabled_features=set(),
+            template_url="https://github.com/Abega1642/ar-infra-template.git",
+            use_template_cache=False,
+        )
+
+        result = use_case.execute(input_dto)
+
+        assert result.success is True
+
+        project_path = input_dto.destination
+        assert not (project_path / "readme.md").exists()
+        assert not (project_path / "licence").exists()
+
+        assert (project_path / "build.gradle").exists()
+        assert (project_path / "settings.gradle").exists()
+
+    def test_use_case_creates_cleaner_when_not_provided(
+        self,
+        template_fetcher_with_artifacts: Mock,
+        feature_manager_simple: Mock,
+        gradle_writer_simple: Mock,
+        package_renamer_simple: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that use case creates cleaner instance when not injected."""
+        fake_git_initializer = Mock()
+        fake_annotation_writer = Mock()
+
+        use_case = GenerateProjectUseCase(
+            template_fetcher=template_fetcher_with_artifacts,
+            feature_manager=feature_manager_simple,
+            gradle_writer=gradle_writer_simple,
+            package_renamer=package_renamer_simple,
+            git_initializer=fake_git_initializer,
+            annotation_writer=fake_annotation_writer,
+            artifact_cleaner=None,
+        )
+
+        input_dto = GenerateProjectInput(
+            group_id=GroupId("dev.razafindratelo"),
+            artifact_id=ArtifactId("backend-api"),
+            version=Version("1.0.0"),
+            destination=tmp_path / "my-project",
+            enabled_features=set(),
+            template_url="https://github.com/Abega1642/ar-infra-template.git",
+            use_template_cache=False,
+        )
+
+        with patch(
+            "src.ar_infra.application.use_cases.generate_project_use_case.DevelopmentArtifactCleaner"
+        ) as mock_cleaner_class:
+            mock_cleaner_instance = Mock()
+            mock_cleaner_instance.clean.return_value = 8
+            mock_cleaner_instance.clean_empty_parent_directories.return_value = 1
+            mock_cleaner_class.return_value = mock_cleaner_instance
+
+            result = use_case.execute(input_dto)
+
+            assert result.success is True
+            mock_cleaner_class.assert_called_with(input_dto.destination)
+            mock_cleaner_instance.clean.assert_called_once()
+            assert mock_cleaner_instance.clean_empty_parent_directories.call_count == 2

--- a/tests/unit/infrastructure/test_development_artifact_remover.py
+++ b/tests/unit/infrastructure/test_development_artifact_remover.py
@@ -1,0 +1,347 @@
+"""Tests for the DevelopmentArtifactCleaner class."""
+
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from src.ar_infra.infrastructure.template.development_artifact_remover import (
+    DevelopmentArtifactCleaner,
+)
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Path:
+    """Create a temporary project structure for testing."""
+    project_root = tmp_path / "test_project"
+    project_root.mkdir()
+
+    (project_root / ".github").mkdir()
+    (project_root / ".github" / "dependabot.yml").write_text("version: 2")
+    (project_root / ".github" / "CODEOWNERS").write_text("* @owner")
+    (project_root / "ar-infra-logo.png").write_bytes(b"fake image data")
+    (project_root / "code_of_conduct.md").write_text("# Code of Conduct")
+    (project_root / "readme.md").write_text("# README")
+    (project_root / "security.md").write_text("# Security")
+    (project_root / "contributing.md").write_text("# Contributing")
+    (project_root / "licence").write_text("MIT License")
+
+    # Create some files that should remain
+    (project_root / "main.py").write_text("print('hello')")
+    (project_root / "config.json").write_text("{}")
+
+    return project_root
+
+
+@pytest.fixture
+def cleaner(temp_project: Path) -> DevelopmentArtifactCleaner:
+    """Create a cleaner instance for the temporary project."""
+    return DevelopmentArtifactCleaner(temp_project)
+
+
+class TestDevelopmentArtifactCleanerInitialization:
+    """Test initialization of DevelopmentArtifactCleaner."""
+
+    def test_init_with_valid_directory(self, temp_project: Path) -> None:
+        """Test initialization with a valid directory."""
+        cleaner = DevelopmentArtifactCleaner(temp_project)
+        assert cleaner._project_root == temp_project.resolve()
+
+    def test_init_with_nonexistent_directory(self, tmp_path: Path) -> None:
+        """Test initialization fails with non-existent directory."""
+        nonexistent = tmp_path / "does_not_exist"
+        with pytest.raises(ValueError, match="does not exist"):
+            DevelopmentArtifactCleaner(nonexistent)
+
+    def test_init_with_file_instead_of_directory(self, tmp_path: Path) -> None:
+        """Test initialization fails when given a file instead of directory."""
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("content")
+        with pytest.raises(ValueError, match="not a directory"):
+            DevelopmentArtifactCleaner(file_path)
+
+
+class TestPathValidation:
+    """Test path validation and security."""
+
+    def test_validate_path_within_project(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test that valid paths within project are accepted."""
+        valid_path = temp_project / "readme.md"
+        validated = cleaner._validate_path(valid_path)
+        assert validated == valid_path.resolve()
+
+    def test_validate_path_prevents_traversal_absolute(
+        self, cleaner: DevelopmentArtifactCleaner, tmp_path: Path
+    ) -> None:
+        """Test that absolute paths outside project are rejected."""
+        outside_path = tmp_path / "outside.txt"
+        with pytest.raises(ValueError, match="outside project root"):
+            cleaner._validate_path(outside_path)
+
+    def test_validate_path_prevents_traversal_relative(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test that relative paths escaping project are rejected."""
+        traversal_path = temp_project / ".." / ".." / "etc" / "passwd"
+        with pytest.raises(ValueError, match="outside project root"):
+            cleaner._validate_path(traversal_path)
+
+    def test_validate_path_prevents_symlink_escape(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path, tmp_path: Path
+    ) -> None:
+        """Test that symlinks pointing outside project are rejected."""
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        symlink_path = temp_project / "evil_link"
+
+        try:
+            symlink_path.symlink_to(outside_dir)
+            with pytest.raises(ValueError, match="outside project root"):
+                cleaner._validate_path(symlink_path)
+        except OSError:
+            # Symlink creation might fail on some systems
+            pytest.skip("Symlink creation not supported")
+
+
+class TestRemoveSingleArtifact:
+    """Test removing individual artifacts."""
+
+    def test_remove_existing_file(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing an existing file."""
+        assert (temp_project / "readme.md").exists()
+        result = cleaner.remove_artifact("readme.md")
+        assert result is True
+        assert not (temp_project / "readme.md").exists()
+
+    def test_remove_nonexistent_file(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing a non-existent file returns False."""
+        result = cleaner.remove_artifact("nonexistent.md")
+        assert result is False
+
+    def test_remove_file_in_subdirectory(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing a file in a subdirectory."""
+        assert (temp_project / ".github" / "dependabot.yml").exists()
+        result = cleaner.remove_artifact(".github/dependabot.yml")
+        assert result is True
+        assert not (temp_project / ".github" / "dependabot.yml").exists()
+
+    def test_remove_entire_directory(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing an entire directory with contents."""
+        github_dir = temp_project / ".github"
+        assert github_dir.exists()
+        assert (github_dir / "dependabot.yml").exists()
+        assert (github_dir / "CODEOWNERS").exists()
+
+        result = cleaner.remove_artifact(".github")
+        assert result is True
+        assert not github_dir.exists()
+
+    def test_remove_nested_directory_structure(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing deeply nested directory structures."""
+        nested_dir = temp_project / "a" / "b" / "c"
+        nested_dir.mkdir(parents=True)
+        (nested_dir / "file.txt").write_text("content")
+
+        result = cleaner.remove_artifact("a")
+        assert result is True
+        assert not (temp_project / "a").exists()
+
+    def test_remove_with_path_traversal_attempt(self, cleaner: DevelopmentArtifactCleaner) -> None:
+        """Test that path traversal attempts are rejected."""
+        with pytest.raises(ValueError, match="outside project root"):
+            cleaner.remove_artifact("../../etc/passwd")
+
+
+class TestCleanMultipleArtifacts:
+    """Test cleaning multiple artifacts at once."""
+
+    def test_clean_default_artifacts(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test cleaning with default artifact list."""
+        removed_count = cleaner.clean()
+
+        assert not (temp_project / ".github" / "dependabot.yml").exists()
+        assert not (temp_project / ".github" / "CODEOWNERS").exists()
+        assert not (temp_project / "ar-infra-logo.png").exists()
+        assert not (temp_project / "code_of_conduct.md").exists()
+        assert not (temp_project / "readme.md").exists()
+        assert not (temp_project / "security.md").exists()
+        assert not (temp_project / "contributing.md").exists()
+        assert not (temp_project / "licence").exists()
+
+        assert (temp_project / "main.py").exists()
+        assert (temp_project / "config.json").exists()
+
+        assert removed_count == 8
+
+    def test_clean_custom_artifacts(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test cleaning with a custom artifact list."""
+        custom_artifacts = ["readme.md", "licence"]
+        removed_count = cleaner.clean(artifacts=custom_artifacts)
+
+        assert not (temp_project / "readme.md").exists()
+        assert not (temp_project / "licence").exists()
+        assert (temp_project / "security.md").exists()  # Not in custom list
+        assert removed_count == 2
+
+    def test_clean_with_nonexistent_artifacts(self, cleaner: DevelopmentArtifactCleaner) -> None:
+        """Test cleaning with some non-existent artifacts."""
+        artifacts = ["readme.md", "nonexistent1.txt", "nonexistent2.txt"]
+        removed_count = cleaner.clean(artifacts=artifacts)
+        assert removed_count == 1  # Only readme.md existed
+
+    def test_clean_empty_list(self, cleaner: DevelopmentArtifactCleaner) -> None:
+        """Test cleaning with an empty artifact list."""
+        removed_count = cleaner.clean(artifacts=[])
+        assert removed_count == 0
+
+
+class TestCleanEmptyParentDirectories:
+    """Test cleaning up empty parent directories."""
+
+    def test_clean_empty_parents_after_file_removal(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing empty parent directories after file removal."""
+        cleaner.remove_artifact(".github/dependabot.yml")
+        cleaner.remove_artifact(".github/CODEOWNERS")
+
+        assert (temp_project / ".github").exists()
+
+        removed_count = cleaner.clean_empty_parent_directories(".github/dependabot.yml")
+        assert removed_count == 1
+        assert not (temp_project / ".github").exists()
+
+    def test_clean_empty_parents_nested(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test removing nested empty directories."""
+        nested_path = temp_project / "a" / "b" / "c" / "file.txt"
+        nested_path.parent.mkdir(parents=True)
+        nested_path.write_text("content")
+
+        cleaner.remove_artifact("a/b/c/file.txt")
+        removed_count = cleaner.clean_empty_parent_directories("a/b/c/file.txt")
+
+        assert removed_count == 3
+        assert not (temp_project / "a").exists()
+
+    def test_clean_empty_parents_stops_at_non_empty(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test that cleanup stops when encountering non-empty directory."""
+        nested_path = temp_project / "a" / "b" / "file.txt"
+        nested_path.parent.mkdir(parents=True)
+        nested_path.write_text("content")
+        (temp_project / "a" / "keeper.txt").write_text("keep me")
+
+        cleaner.remove_artifact("a/b/file.txt")
+        removed_count = cleaner.clean_empty_parent_directories("a/b/file.txt")
+
+        assert removed_count == 1
+        assert (temp_project / "a").exists()
+        assert (temp_project / "a" / "keeper.txt").exists()
+
+    def test_clean_empty_parents_does_not_remove_project_root(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test that project root is never removed."""
+        file_path = temp_project / "file.txt"
+        file_path.write_text("content")
+
+        cleaner.remove_artifact("file.txt")
+        removed_count = cleaner.clean_empty_parent_directories("file.txt")
+
+        assert removed_count == 0
+        assert temp_project.exists()
+
+
+class TestErrorHandling:
+    """Test error handling and edge cases."""
+
+    def test_remove_artifact_with_permission_error(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test handling of permission errors during removal."""
+        if not hasattr(Path, "chmod"):
+            pytest.skip("chmod not available on this platform")
+
+        protected_file = temp_project / "protected.txt"
+        protected_file.write_text("content")
+
+        temp_project.chmod(0o444)
+
+        try:
+            error = re.escape(f"[Errno 13] Permission denied: '{protected_file}'")
+            with pytest.raises(OSError, match=error):
+                cleaner.remove_artifact("protected.txt")
+        finally:
+            temp_project.chmod(0o755)
+
+    def test_logging_on_successful_removal(
+        self, cleaner: DevelopmentArtifactCleaner, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that successful removals are logged."""
+        with caplog.at_level(logging.INFO):
+            cleaner.remove_artifact("readme.md")
+
+        assert "Removed file: readme.md" in caplog.text
+
+    def test_logging_on_nonexistent_artifact(
+        self, cleaner: DevelopmentArtifactCleaner, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that non-existent artifacts are logged at debug level."""
+        with caplog.at_level(logging.DEBUG):
+            cleaner.remove_artifact("nonexistent.txt")
+
+        assert "does not exist" in caplog.text
+
+
+class TestIntegrationScenarios:
+    """Test complete integration scenarios."""
+
+    def test_full_cleanup_workflow(self, temp_project: Path) -> None:
+        """Test a complete cleanup workflow."""
+        cleaner = DevelopmentArtifactCleaner(temp_project)
+
+        removed_count = cleaner.clean()
+        assert removed_count == 8
+
+        cleaner.clean_empty_parent_directories(".github/dependabot.yml")
+
+        assert not (temp_project / ".github").exists()
+        assert not (temp_project / "readme.md").exists()
+        assert (temp_project / "main.py").exists()
+        assert (temp_project / "config.json").exists()
+
+        removed_count_2 = cleaner.clean()
+        assert removed_count_2 == 0
+
+    def test_cleanup_with_mixed_success_and_failure(
+        self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
+    ) -> None:
+        """Test cleanup with some artifacts present and some missing."""
+        (temp_project / "readme.md").unlink()
+        (temp_project / "licence").unlink()
+
+        removed_count = cleaner.clean()
+
+        assert removed_count == 6
+        assert not (temp_project / "security.md").exists()
+        assert not (temp_project / "contributing.md").exists()

--- a/tests/unit/infrastructure/test_development_artifact_remover.py
+++ b/tests/unit/infrastructure/test_development_artifact_remover.py
@@ -1,6 +1,7 @@
 """Tests for the DevelopmentArtifactCleaner class."""
 
 import logging
+import platform
 import re
 from pathlib import Path
 
@@ -275,6 +276,7 @@ class TestCleanEmptyParentDirectories:
 class TestErrorHandling:
     """Test error handling and edge cases."""
 
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Windows-specific tests")
     def test_remove_artifact_with_permission_error(
         self, cleaner: DevelopmentArtifactCleaner, temp_project: Path
     ) -> None:

--- a/tests/unit/infrastructure/test_facadeit_handler.py
+++ b/tests/unit/infrastructure/test_facadeit_handler.py
@@ -16,18 +16,22 @@ public abstract class FacadeIT {
   private static final BucketConf BUCKET_CONF = new BucketConf();
   private static final EmailConf EMAIL_CONF = new EmailConf();
 
+  @BeforeAll
   static void beforeAll() {
     POSTGRES_CONF.start();
     RABBITMQ_CONF.start();
     BUCKET_CONF.start();
     EMAIL_CONF.start();
-  }
 
-  static void shutdown() {
-    POSTGRES_CONF.stop();
-    RABBITMQ_CONF.stop();
-    BUCKET_CONF.stop();
-    EMAIL_CONF.stop();
+    getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  POSTGRES_CONF.stop();
+                  RABBITMQ_CONF.stop();
+                  BUCKET_CONF.stop();
+                  EMAIL_CONF.stop();
+                }));
   }
 
   static void configure(DynamicPropertyRegistry registry) {
@@ -92,6 +96,17 @@ class TestFacadeITHandler:
         assert "RabbitMQConf" in content
         assert "BucketConf" in content
         assert "EmailConf" in content
+
+    def test_before_all_removed_when_no_features_enabled(self, facade_path: Path) -> None:
+        FacadeITHandler().apply_feature_selection(
+            facade_path.parents[5],
+            set(),
+        )
+
+        content = self._read(facade_path)
+
+        assert "@BeforeAll" not in content
+        assert "static void beforeAll" not in content
 
     def test_no_features_enabled(self, facade_path: Path) -> None:
         FacadeITHandler().apply_feature_selection(

--- a/tests/unit/infrastructure/test_project_signature.py
+++ b/tests/unit/infrastructure/test_project_signature.py
@@ -12,6 +12,7 @@ from src.ar_infra.infrastructure.template.project_signature import (
     InfraGeneratedAnnotationWriter,
     ProjectSignature,
 )
+from src.ar_infra.properties import CLI_VERSION
 
 
 class TestProjectSignature:
@@ -74,14 +75,14 @@ class TestProjectSignature:
         assert signature.version == "2.5.0"
 
     def test_default_cli_version(self) -> None:
-        """Test that default CLI version is 1.0.0."""
+        """Test default CLI version"""
         signature = ProjectSignature.generate(
             group_id=GroupId("com.test"),
             artifact_id=ArtifactId("myapp"),
             version=Version("1.0.0"),
         )
 
-        assert signature.version == "1.0.0"
+        assert signature.version == CLI_VERSION
 
     def test_generated_at_is_iso_format(self) -> None:
         """Test that generated_at is in ISO 8601 format."""


### PR DESCRIPTION
- Some files are meant for ar-infra-template development only and not supposed to appear on generated project.
    -   Solution: implementing `DevelopmentArtifactCleaner` class
- Update `FacadeITHandler` :
   -   Add removal of `beforeAll` method when no feature is added by the user 