### PR TITLE
feat: add RestExceptionHandlerManager

### DIFF
--- a/src/ar_infra/cli/prompt/interactive_prompt.py
+++ b/src/ar_infra/cli/prompt/interactive_prompt.py
@@ -108,11 +108,11 @@ class InteractivePrompt:
             try:
                 validated_path = self.security_validator.validate_destination_path(path_str)
                 return self._handle_validated_path(validated_path)
-            except DangerousPathError as exc:
-                if not self._handle_security_exception(exc, "SECURITY WARNING"):
-                    raise
-            except PathSecurityError as exc:
-                if not self._handle_security_exception(exc, "Security Error"):
+            except (DangerousPathError, PathSecurityError) as exc:
+                error_type = (
+                    "SECURITY WARNING" if isinstance(exc, DangerousPathError) else "Security Error"
+                )
+                if not self._handle_security_exception(exc, error_type):
                     raise
             except (ValueError, OSError) as exc:
                 if not self._handle_general_error(exc):
@@ -157,7 +157,7 @@ class InteractivePrompt:
         """Create directory at given path."""
         try:
             path.mkdir(parents=True, exist_ok=True)
-        except (OSError, PermissionError) as exc:
+        except OSError as exc:
             print(f"\nError: Cannot create directory: {exc}\nPlease choose a different path.\n")
             raise
 
@@ -217,21 +217,26 @@ class InteractivePrompt:
                 if not retry:
                     raise
 
-    def _handle_existing_directory(self, destination: Path, project_dir_name: str) -> Path:
+    def _handle_existing_directory(self, destination: Path, project_dir_name: str) -> None:
         """
         Handle the case where project directory already exists.
+
+        Raises appropriate exceptions if the directory cannot be used.
 
         Args:
             destination: Destination path
             project_dir_name: Project directory name
 
-        Returns:
-            Final destination path to use
+        Raises:
+            ValueError: If path exists but is not a directory
+            PermissionError: If directory cannot be accessed
+            FileExistsError: If directory exists and user chooses not to use it
+            KeyboardInterrupt: If user cancels the operation
         """
         project_path = destination / project_dir_name
 
         if not project_path.exists():
-            return destination
+            return
 
         if not project_path.is_dir():
             raise ValueError(
@@ -240,7 +245,7 @@ class InteractivePrompt:
 
         try:
             has_content = any(project_path.iterdir())
-        except (OSError, PermissionError) as exc:
+        except OSError as exc:
             raise PermissionError(f"Cannot access directory '{project_path}': {exc}") from exc
 
         if not has_content:
@@ -251,7 +256,7 @@ class InteractivePrompt:
             ).ask()
 
             if use_empty:
-                return destination
+                return
             raise FileExistsError(
                 f"Directory '{project_path}' already exists. "
                 "Please choose a different name or destination."

--- a/src/ar_infra/domain/entities/path_resolver.py
+++ b/src/ar_infra/domain/entities/path_resolver.py
@@ -433,22 +433,18 @@ class SafeProjectPathResolver:
         test_file = None
         try:
             test_file = self.destination / ".ar_infra_write_test"
-            with Path.open(test_file, "w", encoding="utf-8"):
-                pass
+            test_file.write_text("", encoding="utf-8")
         except OSError as err:
             raise PermissionError(
                 f"No write permission for destination directory '{self.destination}'"
             ) from err
         finally:
             if test_file and test_file.exists():
-                try:
-                    test_file.unlink()
-                except OSError:
-                    pass
+                test_file.unlink(missing_ok=True)
 
     def _directory_has_content(self, directory: Path) -> bool:
         """Check if directory has any content."""
         try:
             return any(directory.iterdir())
-        except (OSError, PermissionError):
+        except OSError:
             return True  # Assume has content if we can't check

--- a/src/ar_infra/infrastructure/processor/bot.py
+++ b/src/ar_infra/infrastructure/processor/bot.py
@@ -106,7 +106,7 @@ class BotGitHandler:
         self._stage_all_files(project_path)
         self._create_initial_commit(project_path, commit_message)
 
-        log.info("Git repository initialized with bot commit at: %s", project_path)
+        log.info("\nGit repository initialized with bot commit at: %s\n", project_path)
 
     def generate_and_initialize_repo(
         self,
@@ -133,7 +133,7 @@ class BotGitHandler:
 
         self.initialize_repository(output_path, initial_branch, commit_message)
 
-        log.info("Project generated and initial commit created by bot at: %s", output_path)
+        log.info("\nProject generated and initial commit created by bot at: %s\n", output_path)
 
     def _remove_existing_git_directory(self, path: Path) -> None:
         git_dir = path / ".git"

--- a/src/ar_infra/infrastructure/template/facadeit_handler.py
+++ b/src/ar_infra/infrastructure/template/facadeit_handler.py
@@ -69,28 +69,39 @@ class FacadeITHandler:
 
     @staticmethod
     def _remove_empty_before_all(lines: list[str]) -> list[str]:
+        """Remove @BeforeAll annotated methods from the lines."""
         result: list[str] = []
         i = 0
 
         while i < len(lines):
-            line = lines[i].strip()
-
-            if line == "@BeforeAll":
-                # Skip until the closing brace of the method
-                i += 1
-                brace_depth = 0
-                while i < len(lines):
-                    if "{" in lines[i]:
-                        brace_depth += 1
-                    if "}" in lines[i]:
-                        brace_depth -= 1
-                        if brace_depth <= 0:
-                            i += 1
-                            break
-                    i += 1
+            if lines[i].strip() == "@BeforeAll":
+                i = FacadeITHandler._skip_before_all_method(lines, i)
                 continue
 
             result.append(lines[i])
             i += 1
 
         return result
+
+    @staticmethod
+    def _skip_before_all_method(lines: list[str], start_index: int) -> int:
+        """Skip past a @BeforeAll method and return the next index to process."""
+        i = start_index + 1
+        brace_depth = 0
+
+        while i < len(lines):
+            brace_depth = FacadeITHandler._update_brace_depth(lines[i], brace_depth)
+            i += 1
+
+            if brace_depth <= 0:
+                break
+
+        return i
+
+    @staticmethod
+    def _update_brace_depth(line: str, current_depth: int) -> int:
+        """Update brace depth based on braces in the line."""
+        depth = current_depth
+        depth += line.count("{")
+        depth -= line.count("}")
+        return depth

--- a/src/ar_infra/infrastructure/template/rest_exception_manager.py
+++ b/src/ar_infra/infrastructure/template/rest_exception_manager.py
@@ -1,0 +1,187 @@
+"""REST exception handler manager for feature-based exception pruning."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Final
+
+from src.ar_infra.domain.enums.template_feature import TemplateFeature
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class RestExceptionHandlerManager:
+    """Prune ApiExceptionHandler.java based on enabled infrastructure features."""
+
+    _FEATURE_EXCEPTION_MAPPING: Final[dict[TemplateFeature, set[str]]] = {
+        TemplateFeature.S3_BUCKET: {
+            "BucketHealthCheckException",
+            "BucketOperationException",
+            "DirectoryUploadException",
+        },
+        TemplateFeature.EMAIL: {
+            "EmailHealthCheckException",
+            "EmailSendException",
+        },
+        TemplateFeature.POSTGRESQL: {
+            "EntityNotFoundException",
+            "ConstraintViolationException",
+            "DataIntegrityViolationException",
+        },
+    }
+
+    def apply_feature_selection(
+        self,
+        template_dir: Path,
+        enabled_features: set[TemplateFeature],
+    ) -> None:
+        handler_path = self._find_exception_handler(template_dir)
+        if handler_path is None:
+            return
+
+        disabled_exceptions = self._get_disabled_exceptions(enabled_features)
+        if not disabled_exceptions:
+            return
+
+        content = handler_path.read_text(encoding="utf-8")
+        filtered = self._remove_exception_handlers(content, disabled_exceptions)
+        handler_path.write_text(filtered, encoding="utf-8")
+
+    def _get_disabled_exceptions(self, enabled_features: set[TemplateFeature]) -> set[str]:
+        disabled_features = set(self._FEATURE_EXCEPTION_MAPPING) - enabled_features
+        return {
+            exc for feature in disabled_features for exc in self._FEATURE_EXCEPTION_MAPPING[feature]
+        }
+
+    @staticmethod
+    def _find_exception_handler(template_dir: Path) -> Path | None:
+        matches = list(template_dir.rglob("ApiExceptionHandler.java"))
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise RuntimeError("Multiple ApiExceptionHandler.java files found")
+        return matches[0]
+
+    @staticmethod
+    def _remove_exception_handlers(content: str, disabled_exceptions: set[str]) -> str:
+        """Remove exception handler methods based on disabled exceptions."""
+        lines = content.splitlines(keepends=True)
+
+        methods_to_remove = RestExceptionHandlerManager._find_methods_to_remove(
+            lines, disabled_exceptions
+        )
+
+        if not methods_to_remove:
+            return content
+
+        for start_line, end_line in sorted(methods_to_remove, reverse=True):
+            del lines[start_line : end_line + 1]
+
+        return "".join(lines)
+
+    @staticmethod
+    def _extract_exception_classes(annotation_line: str) -> set[str]:
+        """Extract exception class names from @ExceptionHandler annotation."""
+        exceptions: set[str] = set()
+
+        match = re.search(r"@ExceptionHandler\s*\((.*?)\)", annotation_line)
+        if not match:
+            return exceptions
+
+        content = match.group(1)
+
+        exception_matches = re.findall(r"(\w+Exception)\.class", content)
+        exceptions.update(exception_matches)
+
+        return exceptions
+
+    @staticmethod
+    def _find_methods_to_remove(
+        lines: list[str], disabled_exceptions: set[str]
+    ) -> list[tuple[int, int]]:
+        """Find the line ranges of methods that should be removed."""
+        methods_to_remove: list[tuple[int, int]] = []
+        i = 0
+
+        while i < len(lines):
+            line = lines[i].strip()
+
+            if not line.startswith("@ExceptionHandler"):
+                i += 1
+                continue
+
+            next_index = RestExceptionHandlerManager._process_exception_handler(
+                lines, i, disabled_exceptions, methods_to_remove
+            )
+            i = next_index
+
+        return methods_to_remove
+
+    @staticmethod
+    def _process_exception_handler(
+        lines: list[str],
+        current_line: int,
+        disabled_exceptions: set[str],
+        methods_to_remove: list[tuple[int, int]],
+    ) -> int:
+        """Process an @ExceptionHandler annotation and determine if method should be removed."""
+        line = lines[current_line].strip()
+        handled_exceptions = RestExceptionHandlerManager._extract_exception_classes(line)
+
+        if "Exception" in handled_exceptions:
+            return current_line + 1
+
+        if not handled_exceptions & disabled_exceptions:
+            return current_line + 1
+
+        start_line = RestExceptionHandlerManager._find_method_start(lines, current_line)
+
+        end_line = RestExceptionHandlerManager._find_method_end(lines, current_line)
+
+        methods_to_remove.append((start_line, end_line))
+        return end_line + 1
+
+    @staticmethod
+    def _find_method_start(lines: list[str], annotation_line: int) -> int:
+        """Find the starting line of a method by looking backwards for annotations."""
+        start_line = annotation_line
+        while start_line > 0 and lines[start_line - 1].strip().startswith("@"):
+            start_line -= 1
+        return start_line
+
+    @staticmethod
+    def _find_method_end(lines: list[str], start_line: int) -> int:
+        """Find the closing brace of a method starting from the annotation line."""
+        brace_depth = 0
+        found_opening = False
+
+        for i in range(start_line, len(lines)):
+            closing_brace_line = RestExceptionHandlerManager._process_line_braces(
+                lines[i], brace_depth, found_opening=found_opening
+            )
+
+            if closing_brace_line is not None:
+                return i
+
+            brace_depth += lines[i].count("{") - lines[i].count("}")
+            if "{" in lines[i]:
+                found_opening = True
+
+        return len(lines) - 1
+
+    @staticmethod
+    def _process_line_braces(line: str, brace_depth: int, *, found_opening: bool) -> int | None:
+        """Process braces in a line and return line number if method end is found."""
+        for char in line:
+            if char == "{":
+                found_opening = True
+                brace_depth += 1
+            elif char == "}":
+                brace_depth -= 1
+
+                if found_opening and brace_depth == 0:
+                    return 0  # Signal that we found the end
+
+        return None

--- a/tests/fixtures/api_exception_handler_sample.py
+++ b/tests/fixtures/api_exception_handler_sample.py
@@ -1,0 +1,159 @@
+API_EXCEPTION_HANDLER_SAMPLE = """
+package com.example.arinfra.endpoint.rest.controller;
+
+import com.example.arinfra.exception.bucket.BucketHealthCheckException;
+import com.example.arinfra.exception.bucket.BucketOperationException;
+import com.example.arinfra.exception.health.EmailHealthCheckException;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Sl4j
+public class ApiExceptionHandler {
+
+  @ExceptionHandler(BucketHealthCheckException.class)
+  public ResponseEntity<ErrorResponse> handleBucketHealthCheckException(
+      BucketHealthCheckException ex, WebRequest request) {
+
+    log.error(
+        "Bucket health check failed at path: {}, error code: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getErrorCode()),
+        ex);
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            ex.getMessage(),
+            getRequestPath(request),
+            ex.getErrorCode());
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @ExceptionHandler(EmailHealthCheckException.class)
+  public ResponseEntity<ErrorResponse> handleEmailHealthCheckException(
+      EmailHealthCheckException ex, WebRequest request) {
+
+    log.error(
+        "Email health check failed at path: {}, test case: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getTestCaseName()),
+        ex);
+
+    String errorMessage =
+        format(
+            "Email health check failed at test case '%s': %s",
+            ex.getTestCaseName(),
+            ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage());
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            errorMessage,
+            getRequestPath(request),
+            "EMAIL_HEALTH_CHECK_FAILED");
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleEntityNotFoundException(
+      EntityNotFoundException ex, WebRequest request) {
+
+    log.warn(
+        "Entity not found at path: {}, reason: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getMessage()));
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.NOT_FOUND, ex.getMessage(), getRequestPath(request), "ENTITY_NOT_FOUND");
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(BucketOperationException.class)
+  public ResponseEntity<ErrorResponse> handleBucketOperationException(
+      BucketOperationException ex, WebRequest request) {
+
+    log.error(
+        "Bucket operation failed at path: {}, error code: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getErrorCode()),
+        ex);
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ex.getMessage(),
+            getRequestPath(request),
+            ex.getErrorCode());
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, WebRequest request) {
+    log.error(
+        "Unexpected error at path: {}, exception type: {}, message: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getClass().getName()),
+        forJava(ex.getMessage()),
+        ex);
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "An internal server error occurred",
+            getRequestPath(request),
+            "INTERNAL_SERVER_ERROR");
+    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+      ConstraintViolationException ex, WebRequest request) {
+
+    String message =
+        ex.getConstraintViolations().stream()
+            .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+            .collect(Collectors.joining(", "));
+
+    log.warn(
+        "Constraint violation at path: {}, violations: {}",
+        forJava(getRequestPath(request)),
+        forJava(message));
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.BAD_REQUEST, message, getRequestPath(request), "INVALID_PARAMETER");
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(HandlerMethodValidationException.class)
+  public ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(
+      HandlerMethodValidationException ex, WebRequest request) {
+
+    log.warn(
+        "Handler method validation failed at path: {}, message: {}",
+        forJava(getRequestPath(request)),
+        forJava(ex.getMessage()));
+
+    var errorResponse =
+        ErrorResponse.of(
+            HttpStatus.BAD_REQUEST, ex.getMessage(), getRequestPath(request), "VALIDATION_ERROR");
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+  }
+
+  private String getRequestPath(WebRequest request) {
+    if (request instanceof ServletWebRequest servletWebRequest)
+      return servletWebRequest.getRequest().getRequestURI();
+
+    return "N/A";
+  }
+}
+"""

--- a/tests/unit/infrastructure/test_facadeit_handler.py
+++ b/tests/unit/infrastructure/test_facadeit_handler.py
@@ -9,6 +9,10 @@ from src.ar_infra.infrastructure.template.facadeit_handler import FacadeITHandle
 
 
 FACADE_CONTENT = """
+@Slf4j
+@InfraGenerated
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
 public abstract class FacadeIT {
 
   private static final PostgresConf POSTGRES_CONF = new PostgresConf();
@@ -34,11 +38,19 @@ public abstract class FacadeIT {
                 }));
   }
 
-  static void configure(DynamicPropertyRegistry registry) {
+  @SneakyThrows
+  @DynamicPropertySource
+  static void configureProperties(DynamicPropertyRegistry registry) {
     POSTGRES_CONF.configureProperties(registry);
     RABBITMQ_CONF.configureProperties(registry);
     BUCKET_CONF.configureProperties(registry);
     EMAIL_CONF.configureProperties(registry);
+
+    Class<?> envConfClazz = EnvConf.class;
+    var configureMethod =
+        envConfClazz.getDeclaredMethod("configureProperties", DynamicPropertyRegistry.class);
+    var envConfInstance = envConfClazz.getConstructor().newInstance();
+    configureMethod.invoke(envConfInstance, registry);
   }
 }
 """.lstrip()

--- a/tests/unit/infrastructure/test_rest_exception_manager.py
+++ b/tests/unit/infrastructure/test_rest_exception_manager.py
@@ -1,0 +1,181 @@
+"""Tests for RestExceptionHandlerManager."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
+
+import pytest
+from tests.fixtures.api_exception_handler_sample import API_EXCEPTION_HANDLER_SAMPLE
+
+from src.ar_infra.domain.enums.template_feature import TemplateFeature
+from src.ar_infra.infrastructure.template.rest_exception_manager import RestExceptionHandlerManager
+
+
+@pytest.fixture
+def sample_exception_handler() -> str:
+    """Sample ApiExceptionHandler.java content."""
+    return API_EXCEPTION_HANDLER_SAMPLE
+
+
+@pytest.fixture
+def temp_project_dir(tmp_path_factory: TempPathFactory, sample_exception_handler: str) -> Path:
+    """Create temporary project directory with ApiExceptionHandler.java."""
+    project_dir = tmp_path_factory.mktemp("test_project")
+    handler_dir = project_dir / "src" / "main" / "java" / "com" / "example" / "arinfra"
+    handler_dir = handler_dir / "endpoint" / "rest" / "controller"
+    handler_dir.mkdir(parents=True)
+
+    handler_file = handler_dir / "ApiExceptionHandler.java"
+    handler_file.write_text(sample_exception_handler, encoding="utf-8")
+
+    return project_dir
+
+
+class TestRestExceptionHandlerManager:
+    """Test suite for RestExceptionHandlerManager."""
+
+    def test_remove_bucket_exceptions_only(self, temp_project_dir: Path) -> None:
+        """Test removing only S3 bucket exception handlers."""
+        manager = RestExceptionHandlerManager()
+        enabled_features = {TemplateFeature.EMAIL, TemplateFeature.POSTGRESQL}
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "handleBucketHealthCheckException" not in content
+        assert "handleBucketOperationException" not in content
+        assert "handleEmailHealthCheckException" in content
+        assert "handleEntityNotFoundException" in content
+        assert "handleGenericException" in content
+
+    def test_remove_email_exceptions_only(self, temp_project_dir: Path) -> None:
+        """Test removing only email exception handlers."""
+        manager = RestExceptionHandlerManager()
+        enabled_features = {TemplateFeature.S3_BUCKET, TemplateFeature.POSTGRESQL}
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "handleEmailHealthCheckException" not in content
+        assert "handleBucketHealthCheckException" in content
+        assert "handleEntityNotFoundException" in content
+
+    def test_remove_postgresql_exceptions_only(self, temp_project_dir: Path) -> None:
+        """Test removing only PostgreSQL exception handlers."""
+        manager = RestExceptionHandlerManager()
+        enabled_features = {TemplateFeature.S3_BUCKET, TemplateFeature.EMAIL}
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "handleEntityNotFoundException" not in content
+        assert "handleBucketHealthCheckException" in content
+        assert "handleEmailHealthCheckException" in content
+
+    def test_remove_all_feature_exceptions(self, temp_project_dir: Path) -> None:
+        """Test removing all feature-specific exception handlers."""
+        manager = RestExceptionHandlerManager()
+        enabled_features: set[TemplateFeature] = set()
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "handleBucketHealthCheckException" not in content
+        assert "handleBucketOperationException" not in content
+        assert "handleEmailHealthCheckException" not in content
+        assert "handleEntityNotFoundException" not in content
+        assert "handleGenericException" in content
+
+    def test_keep_all_exceptions_when_all_enabled(self, temp_project_dir: Path) -> None:
+        """Test keeping all exception handlers when all features are enabled."""
+        manager = RestExceptionHandlerManager()
+        enabled_features = {
+            TemplateFeature.S3_BUCKET,
+            TemplateFeature.EMAIL,
+            TemplateFeature.POSTGRESQL,
+        }
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "handleBucketHealthCheckException" in content
+        assert "handleBucketOperationException" in content
+        assert "handleEmailHealthCheckException" in content
+        assert "handleEntityNotFoundException" in content
+        assert "handleGenericException" in content
+
+    def test_no_exception_handler_file(self, tmp_path: Path) -> None:
+        """Test handling when ApiExceptionHandler.java doesn't exist."""
+        manager = RestExceptionHandlerManager()
+        enabled_features = {TemplateFeature.EMAIL}
+
+        # Should not raise an exception
+        manager.apply_feature_selection(tmp_path, enabled_features)
+
+    def test_multiple_exception_handler_files_raises_error(
+        self, tmp_path: Path, sample_exception_handler: str
+    ) -> None:
+        """Test that multiple ApiExceptionHandler.java files raise an error."""
+        dir1 = tmp_path / "src1" / "controller"
+        dir2 = tmp_path / "src2" / "controller"
+        dir1.mkdir(parents=True)
+        dir2.mkdir(parents=True)
+
+        (dir1 / "ApiExceptionHandler.java").write_text(sample_exception_handler, encoding="utf-8")
+        (dir2 / "ApiExceptionHandler.java").write_text(sample_exception_handler, encoding="utf-8")
+
+        manager = RestExceptionHandlerManager()
+        enabled_features = {TemplateFeature.EMAIL}
+
+        with pytest.raises(
+            RuntimeError, match=re.escape("Multiple ApiExceptionHandler.java files found")
+        ):
+            manager.apply_feature_selection(tmp_path, enabled_features)
+
+    def test_preserves_generic_exception_handler(self, temp_project_dir: Path) -> None:
+        """Test that generic Exception handler is always preserved."""
+        manager = RestExceptionHandlerManager()
+        enabled_features: set[TemplateFeature] = set()
+
+        manager.apply_feature_selection(temp_project_dir, enabled_features)
+
+        handler_file = temp_project_dir / "src" / "main" / "java" / "com" / "example"
+        handler_file = handler_file / "arinfra" / "endpoint" / "rest" / "controller"
+        handler_file = handler_file / "ApiExceptionHandler.java"
+
+        content = handler_file.read_text(encoding="utf-8")
+
+        assert "@ExceptionHandler(Exception.class)" in content
+        assert "handleGenericException" in content


### PR DESCRIPTION
When the project is generated, the [`ApiExceptionHandler`](https://github.com/Abega1642/tree/main/src/com/example/arinfra/endpoint/rest/controller/ApiExceptionHandler.java) still contains removed exception class from selected feature.
Solution: implement `RestExceptionHandlerManager` to remove all feature related exception handling