### PR TITLE
feat: add e2e test for interactive mode on Linux & MacOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,11 +11,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 
-# Python files
-[*.py]
-indent_size = 2
-max_line_length = 100
-
 # YAML files
 [*.{yml,yaml}]
 indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,17 @@
 .github/ @Abega1642
 
 # Security & governance files
-SECURITY.md @Abega1642
-CODE_OF_CONDUCT.md @Abega1642
-CONTRIBUTING.md @Abega1642
-dependabot.yml @Abega1642
+security.md @Abega1642
+code_of_conduct.md @Abega1642
+contributing.md @Abega1642
+licence
+.github/dependabot.yml @Abega1642
 
-# Build & tooling
-gradle/ @Abega1642
-build.gradle @Abega1642
-settings.gradle @Abega1642
+.markdownlint.yml @Abega1642
+ar-infra.spec @Abega1642
+ar-infra-cli-banner.png @Abega1642
+ar-infra-logo.png @Abega1642
+Makefile @Abega1642
+src/ @Abega1642 @Abega1642
+scripts/ @Abega1642 @Abega1642
+tests/ @Abega1642

--- a/.github/workflows/ci-e2e-interactive-mode.yml
+++ b/.github/workflows/ci-e2e-interactive-mode.yml
@@ -1,0 +1,105 @@
+name: CI - E2E Interactive Mode Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  interactive-mode-tests:
+    name: Interactive Mode Tests - Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          make install-dev
+
+      - name: Install pexpect
+        run: pip install pexpect
+
+      - name: Configure terminal (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          # Ensure we have a proper terminal
+          export TERM=xterm-256color
+          echo "TERM=xterm-256color" >> $GITHUB_ENV
+
+      - name: Configure terminal (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # Set UTF-8 encoding for Windows
+          echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
+          echo "PYTHONUTF8=1" >> $GITHUB_ENV
+
+      - name: Run interactive mode tests (Unix)
+        if: runner.os != 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_ID: ${{ secrets.BOT_ID_TEST }}
+          BOT_SLUG: ${{ secrets.BOT_SLUG_TEST }}
+          TERM: xterm-256color
+        run: |
+          chmod +x scripts/test-interactive-mode.sh
+          bash scripts/test-interactive-mode.sh
+
+      - name: Run interactive mode tests (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_ID: ${{ secrets.BOT_ID_TEST }}
+          BOT_SLUG: ${{ secrets.BOT_SLUG_TEST }}
+          PYTHONIOENCODING: utf-8
+          PYTHONUTF8: 1
+        run: bash scripts/test-interactive-mode.sh
+
+      - name: Upload interactive test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interactive-test-failures-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: test-interactive-mode/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  interactive-test-summary:
+    name: Interactive Test Summary
+    runs-on: ubuntu-latest
+    needs: [interactive-mode-tests]
+    if: always()
+
+    steps:
+      - name: Check test results
+        run: |
+          echo "=== Interactive Test Summary ==="
+          echo "Interactive Mode Tests: ${{ needs.interactive-mode-tests.result }}"
+
+          if [ "${{ needs.interactive-mode-tests.result }}" != "success" ]; then
+            echo ""
+            echo "Interactive mode tests failed"
+            exit 1
+          else
+            echo ""
+            echo "All interactive mode tests passed"
+          fi

--- a/.github/workflows/ci-e2e-interactive-mode.yml
+++ b/.github/workflows/ci-e2e-interactive-mode.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12"]
 
     steps:
@@ -37,23 +37,13 @@ jobs:
       - name: Install pexpect
         run: pip install pexpect
 
-      - name: Configure terminal (Unix)
-        if: runner.os != 'Windows'
+      - name: Configure terminal
         run: |
           # Ensure we have a proper terminal
           export TERM=xterm-256color
           echo "TERM=xterm-256color" >> $GITHUB_ENV
 
-      - name: Configure terminal (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          # Set UTF-8 encoding for Windows
-          echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
-          echo "PYTHONUTF8=1" >> $GITHUB_ENV
-
-      - name: Run interactive mode tests (Unix)
-        if: runner.os != 'Windows'
+      - name: Run interactive mode tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_ID: ${{ secrets.BOT_ID_TEST }}
@@ -62,17 +52,6 @@ jobs:
         run: |
           chmod +x scripts/test-interactive-mode.sh
           bash scripts/test-interactive-mode.sh
-
-      - name: Run interactive mode tests (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BOT_ID: ${{ secrets.BOT_ID_TEST }}
-          BOT_SLUG: ${{ secrets.BOT_SLUG_TEST }}
-          PYTHONIOENCODING: utf-8
-          PYTHONUTF8: 1
-        run: bash scripts/test-interactive-mode.sh
 
       - name: Upload interactive test results
         if: failure()

--- a/scripts/test-interactive-mode.sh
+++ b/scripts/test-interactive-mode.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=scripts/lib/feature-validator.sh
+source "$SCRIPT_DIR/lib/feature-validator.sh"
+
+readonly BASE_TEST_DIR="test-interactive-mode"
+readonly GROUP="dev.razafindratelo"
+readonly ARTIFACT="interactive-test"
+readonly VERSION="0.0.1"
+
+declare -a FEATURE_COMBINATIONS=(
+  "postgresql:postgresql:postgresql"
+  "rabbitmq:rabbitmq:rabbitmq"
+  "s3_bucket:s3_bucket:s3_bucket"
+  "email:email:email"
+  "postgresql,rabbitmq:postgresql rabbitmq:postgresql rabbitmq"
+  "postgresql,s3_bucket:postgresql s3_bucket:postgresql s3_bucket"
+  "postgresql,email:postgresql email:postgresql email"
+  "rabbitmq,s3_bucket:rabbitmq s3_bucket:rabbitmq s3_bucket"
+  "rabbitmq,email:rabbitmq email:rabbitmq email"
+  "s3_bucket,email:s3_bucket email:s3_bucket email"
+  "postgresql,rabbitmq,s3_bucket:postgresql rabbitmq s3_bucket:postgresql rabbitmq s3_bucket"
+  "postgresql,rabbitmq,email:postgresql rabbitmq email:postgresql rabbitmq email"
+  "postgresql,s3_bucket,email:postgresql s3_bucket email:postgresql s3_bucket email"
+  "rabbitmq,s3_bucket,email:rabbitmq s3_bucket email:rabbitmq s3_bucket email"
+)
+
+check_pexpect_installed() {
+  local python_path="$1"
+  if ! PYTHONPATH="$python_path" python -c "import pexpect" 2>/dev/null; then
+    print_error "The Python 'pexpect' module is required but not installed"
+    print_info "Install it with: pip install pexpect"
+    return 1
+  fi
+  return 0
+}
+
+cleanup() {
+  if [ -d "$BASE_TEST_DIR" ]; then
+    print_info "Cleaning up test directory..."
+    rm -rf "$BASE_TEST_DIR"
+  fi
+}
+
+generate_pexpect_script() {
+  local group="$1"
+  local artifact="$2"
+  local version="$3"
+  local dest_path="$4"
+  local features="$5"
+  local output_file="$6"
+
+  cat > "$output_file" << 'EOF_PEXPECT'
+#!/usr/bin/env python
+import sys
+import os
+import time
+
+IS_WINDOWS = sys.platform.startswith('win')
+
+if IS_WINDOWS:
+    import pexpect.popen_spawn as pexpect_spawn
+else:
+    import pexpect
+
+def main():
+    group = sys.argv[1]
+    artifact = sys.argv[2]
+    version = sys.argv[3]
+    dest_path = sys.argv[4]
+    features = sys.argv[5] if len(sys.argv) > 5 else ""
+
+    # Use popen_spawn on Windows, regular spawn on Unix
+    if IS_WINDOWS:
+        child = pexpect_spawn.PopenSpawn(
+            f'python -m src.ar_infra.cli.main init',
+            encoding='utf-8',
+            timeout=120
+        )
+    else:
+        child = pexpect.spawn(
+            'python',
+            ['-m', 'src.ar_infra.cli.main', 'init'],
+            encoding='utf-8',
+            timeout=120
+        )
+
+    child.logfile = sys.stdout
+
+    try:
+        # Wait for initial prompt and press Enter
+        child.expect('Press Enter to continue', timeout=30)
+        child.sendline('')
+        time.sleep(0.5)
+
+        # Group ID - Clear default "com.example" (11 chars)
+        child.expect('Group ID:', timeout=30)
+        time.sleep(0.3)
+        for _ in range(20):  # Send enough backspaces to clear any default
+            child.send('\x7f')  # Backspace
+            time.sleep(0.05)
+        child.sendline(group)
+        time.sleep(0.5)
+
+        # Artifact ID - Clear default "my-app" (6 chars)
+        child.expect('Artifact ID', timeout=30)
+        time.sleep(0.3)
+        for _ in range(20):  # Send enough backspaces to clear any default
+            child.send('\x7f')  # Backspace
+            time.sleep(0.05)
+        child.sendline(artifact)
+        time.sleep(0.5)
+
+        # Version - Clear default "1.0.0" (5 chars)
+        child.expect('Version:', timeout=30)
+        time.sleep(0.3)
+        for _ in range(20):  # Send enough backspaces to clear any default
+            child.send('\x7f')  # Backspace
+            time.sleep(0.05)
+        child.sendline(version)
+        time.sleep(0.5)
+
+        child.expect('Destination Directory', timeout=30)
+        time.sleep(0.3)
+        for _ in range(20):  # Send enough backspaces to clear any default
+            child.send('\x7f')  # Backspace
+            time.sleep(0.05)
+        child.sendline(dest_path)
+        time.sleep(0.5)
+
+        child.expect('Project Directory Name', timeout=30)
+        time.sleep(0.3)
+        for _ in range(20):  # Send enough backspaces to clear any default
+            child.send('\x7f')  # Backspace
+            time.sleep(0.05)
+        child.sendline(artifact)
+        time.sleep(0.5)
+
+        child.expect('Select Features to Include:', timeout=30)
+        time.sleep(0.5)
+
+        if features:
+            # Parse features: "postgresql rabbitmq" -> ["postgresql", "rabbitmq"]
+            feature_list = features.strip().split()
+
+            feature_map = {
+                'postgresql': 0,
+                'rabbitmq': 1,
+                's3_bucket': 2,
+                'email': 3
+            }
+
+            for feature in feature_list:
+                if feature in feature_map:
+                    pos = feature_map[feature]
+
+                    for _ in range(pos):
+                        child.send('\x1b[B')  # Down arrow key
+                        time.sleep(0.2)
+
+                    child.send(' ')
+                    time.sleep(0.3)
+
+                    for _ in range(pos):
+                        child.send('\x1b[A')  # Up arrow key
+                        time.sleep(0.2)
+
+        time.sleep(0.3)
+        child.sendline('')
+        time.sleep(0.5)
+
+        child.expect('Use cached template', timeout=30)
+        time.sleep(0.3)
+        child.sendline('n')
+        time.sleep(0.5)
+
+        child.expect('Would you like to proceed', timeout=30)
+        time.sleep(0.3)
+        child.sendline('y')
+
+        if IS_WINDOWS:
+            # On Windows, just wait a bit for completion
+            time.sleep(10)
+            child.close()
+        else:
+            child.expect(pexpect.EOF, timeout=300)
+            child.close()
+
+        return child.exitstatus if child.exitstatus is not None else 0
+
+    except Exception as e:
+        error_type = type(e).__name__
+        print(f"\nERROR: {error_type}: {e}", file=sys.stderr)
+
+        if hasattr(child, 'before'):
+            print(f"\nLast output:\n{child.before}", file=sys.stderr)
+
+        child.close(force=True)
+        return 1
+
+if __name__ == '__main__':
+    sys.exit(main())
+EOF_PEXPECT
+
+  chmod +x "$output_file"
+}
+
+run_single_test() {
+  local test_name="$1"
+  local feature_input="$2"
+  local enabled_features="${3:-}"
+
+  local test_dir="$BASE_TEST_DIR/$test_name"
+  local project_dir="$test_dir/$ARTIFACT"
+  local pexpect_script="$PROJECT_ROOT/$test_dir/run-test.py"
+
+  print_info "+++++++++++++++++++++++++++++++++++++++++"
+  print_info "Test: $test_name"
+  print_info "Features: ${enabled_features:-none}"
+  print_info "+++++++++++++++++++++++++++++++++++++++++"
+  echo ""
+
+  mkdir -p "$test_dir"
+
+  local python_path
+  python_path="$(setup_python_path "$PROJECT_ROOT")"
+
+  generate_pexpect_script "$GROUP" "$ARTIFACT" "$VERSION" "./" "$feature_input" "$pexpect_script"
+
+  cd "$test_dir" || return 1
+
+  if ! PYTHONPATH="$python_path" python "$pexpect_script" "$GROUP" "$ARTIFACT" "$VERSION" "./" "$feature_input"; then
+    print_error "Project generation failed"
+    cd "$PROJECT_ROOT" || exit 1
+    return 1
+  fi
+
+  print_success "Project generated"
+  echo ""
+
+  if is_windows; then
+    wait_for_git_unlock "$project_dir" || true
+  fi
+
+  cd "$PROJECT_ROOT" || return 1
+
+  local feature_array=()
+  read -ra feature_array <<< "$enabled_features"
+
+  local validation_errors
+  validation_errors="$(validate_features "$project_dir" "$GROUP" "$ARTIFACT" "${feature_array[@]}")"
+
+  if [ "$validation_errors" -eq 0 ]; then
+    print_success "Feature validation passed"
+    return 0
+  else
+    print_error "Feature validation failed with $validation_errors error(s)"
+    return 1
+  fi
+}
+
+main() {
+  local failed_tests=0
+  local passed_tests=0
+  local total_tests="${#FEATURE_COMBINATIONS[@]}"
+
+  echo "+++++++++++++++++++++++++++++++++++++++++"
+  echo "AR-INFRA Interactive Mode Tests"
+  echo "+++++++++++++++++++++++++++++++++++++++++"
+  echo ""
+
+  PROJECT_ROOT="$(get_project_root)" || exit 1
+
+  local python_path
+  python_path="$(setup_python_path "$PROJECT_ROOT")"
+
+  if ! check_pexpect_installed "$python_path"; then
+    print_info "Attempting to install pexpect..."
+    if pip install pexpect; then
+      print_success "pexpect installed successfully"
+    else
+      print_error "Failed to install pexpect"
+      exit 1
+    fi
+  fi
+
+  cleanup
+  mkdir -p "$BASE_TEST_DIR"
+
+  for combination in "${FEATURE_COMBINATIONS[@]}"; do
+    IFS=':' read -r test_name feature_input enabled_features <<< "$combination"
+
+    if run_single_test "$test_name" "$feature_input" "$enabled_features"; then
+      passed_tests=$((passed_tests + 1))
+    else
+      failed_tests=$((failed_tests + 1))
+    fi
+
+    echo ""
+  done
+
+  echo "+++++++++++++++++++++++++++++++++++++++++"
+  echo "Test Summary"
+  echo "+++++++++++++++++++++++++++++++++++++++++"
+  print_info "Total:  $total_tests"
+  print_success "Passed: $passed_tests"
+  print_error "Failed: $failed_tests"
+  echo ""
+
+  if [ "$failed_tests" -eq 0 ]; then
+    print_success "All interactive mode tests passed!"
+    cleanup
+    exit 0
+  else
+    print_error "Some tests failed. Results kept in $BASE_TEST_DIR"
+    exit 1
+  fi
+}
+
+trap 'print_warning "Interrupted, cleaning up..."; cleanup' INT TERM
+main "$@"

--- a/scripts/test-interactive-mode.sh
+++ b/scripts/test-interactive-mode.sh
@@ -149,6 +149,7 @@ def main():
             # Parse features: "postgresql rabbitmq" -> ["postgresql", "rabbitmq"]
             feature_list = features.strip().split()
 
+            # Map features to their checkbox positions (0-indexed)
             feature_map = {
                 'postgresql': 0,
                 'rabbitmq': 1,
@@ -160,13 +161,16 @@ def main():
                 if feature in feature_map:
                     pos = feature_map[feature]
 
+                    # Navigate to the feature position
                     for _ in range(pos):
                         child.send('\x1b[B')  # Down arrow key
                         time.sleep(0.2)
 
+                    # Select with space
                     child.send(' ')
                     time.sleep(0.3)
 
+                    # Go back to top for next feature
                     for _ in range(pos):
                         child.send('\x1b[A')  # Up arrow key
                         time.sleep(0.2)
@@ -184,8 +188,8 @@ def main():
         time.sleep(0.3)
         child.sendline('y')
 
+        # Wait for completion
         if IS_WINDOWS:
-            # On Windows, just wait a bit for completion
             time.sleep(10)
             child.close()
         else:
@@ -201,7 +205,16 @@ def main():
         if hasattr(child, 'before'):
             print(f"\nLast output:\n{child.before}", file=sys.stderr)
 
-        child.close(force=True)
+        # Properly close/terminate based on platform
+        try:
+            if IS_WINDOWS:
+                if hasattr(child, 'terminate'):
+                    child.terminate(force=True)
+            else:
+                child.close(force=True)
+        except:
+            pass
+
         return 1
 
 if __name__ == '__main__':

--- a/src/ar_infra/cli/ui/help.py
+++ b/src/ar_infra/cli/ui/help.py
@@ -94,7 +94,7 @@ def show_help() -> None:
 
     features_table.add_row("postgresql", "PostgreSQL database support")
     features_table.add_row("rabbitmq", "RabbitMQ message broker")
-    features_table.add_row("s3_bucket", "AWS S3 integration")
+    features_table.add_row("s3_bucket", "AWS S3-compatible (BackBlaze) integration")
     features_table.add_row("email", "Email sending capabilities")
 
     console.print(features_table)


### PR DESCRIPTION
E2E Test on cli mode already exists.
E2E Test is then required to make sure cli mode and interactive mode are correct.

Only MacOS and Linux is set up here because of the incompatibility and complexity of Windows setup with running the ar-infra cli interactive mode.