### PR TITLE
fix: refactor FormatScriptRunner to handle Windows cmd shell

### DIFF
--- a/scripts/test-feature-combinations.sh
+++ b/scripts/test-feature-combinations.sh
@@ -43,7 +43,8 @@ run_single_test() {
   local feature_flag="$2"
   local enabled_features="${3:-}"
 
-  local test_dir="$BASE_TEST_DIR/$test_name"
+  local concatained_test_name="${test_name//,/_}"
+  local test_dir="$BASE_TEST_DIR/$concatained_test_name"
   local project_dir="$test_dir/$ARTIFACT"
 
   print_info "+++++++++++++++++++++++++++++++++++++++++"

--- a/scripts/test-feature-combinations.sh
+++ b/scripts/test-feature-combinations.sh
@@ -19,17 +19,21 @@ declare -a FEATURE_COMBINATIONS=(
   "rabbitmq:--features=rabbitmq:rabbitmq"
   "s3_bucket:--features=s3_bucket:s3_bucket"
   "email:--features=email:email"
-  "postgresql,rabbitmq:--features=postgresql,rabbitmq:postgresql rabbitmq"
-  "postgresql,s3_bucket:--features=postgresql,s3_bucket:postgresql s3_bucket"
-  "postgresql,email:--features=postgresql,email:postgresql email"
-  "rabbitmq,s3_bucket:--features=rabbitmq,s3_bucket:rabbitmq s3_bucket"
-  "rabbitmq,email:--features=rabbitmq,email:rabbitmq email"
-  "s3_bucket,email:--features=s3_bucket,email:s3_bucket email"
-  "postgresql,rabbitmq,s3_bucket:--features=postgresql,rabbitmq,s3_bucket:postgresql rabbitmq s3_bucket"
-  "postgresql,rabbitmq,email:--features=postgresql,rabbitmq,email:postgresql rabbitmq email"
-  "postgresql,s3_bucket,email:--features=postgresql,s3_bucket,email:postgresql s3_bucket email"
-  "rabbitmq,s3_bucket,email:--features=rabbitmq,s3_bucket,email:rabbitmq s3_bucket email"
+
+  "postgresql_rabbitmq:--features=postgresql,rabbitmq:postgresql rabbitmq"
+  "postgresql_s3_bucket:--features=postgresql,s3_bucket:postgresql s3_bucket"
+  "postgresql_email:--features=postgresql,email:postgresql email"
+
+  "rabbitmq_s3_bucket:--features=rabbitmq,s3_bucket:rabbitmq s3_bucket"
+  "rabbitmq_email:--features=rabbitmq,email:rabbitmq email"
+  "s3_bucket_email:--features=s3_bucket,email:s3_bucket email"
+
+  "postgresql_rabbitmq_s3_bucket:--features=postgresql,rabbitmq,s3_bucket:postgresql rabbitmq s3_bucket"
+  "postgresql_rabbitmq_email:--features=postgresql,rabbitmq,email:postgresql rabbitmq email"
+  "postgresql_s3_bucket_email:--features=postgresql,s3_bucket,email:postgresql s3_bucket email"
+  "rabbitmq_s3_bucket_email:--features=rabbitmq,s3_bucket,email:rabbitmq s3_bucket email"
 )
+
 
 cleanup() {
   if [ -d "$BASE_TEST_DIR" ]; then

--- a/src/ar_infra/infrastructure/processor/format_script_runner.py
+++ b/src/ar_infra/infrastructure/processor/format_script_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import shutil
 import subprocess
@@ -76,7 +77,7 @@ class FormatScriptRunner:
         if not script_path.resolve().is_relative_to(project_root):
             raise RuntimeError("Refusing to execute format.sh outside project root")
 
-        if not script_path.stat().st_mode & 0o111:
+        if os.name != "nt" and not script_path.stat().st_mode & 0o111:
             raise RuntimeError("format.sh is not executable")
 
         log.info("Running project formatter: %s", script_path)

--- a/src/ar_infra/infrastructure/processor/format_script_runner.py
+++ b/src/ar_infra/infrastructure/processor/format_script_runner.py
@@ -1,4 +1,4 @@
-"""Runner for project format.sh script."""
+"""Runner for project format script."""
 
 from __future__ import annotations
 
@@ -18,12 +18,53 @@ log = get_logger(__name__)
 
 
 class FormatScriptRunner:
-    """Run the format.sh script at the root of a generated project."""
+    """Run the format script at the root of a generated project."""
 
-    _SCRIPT_NAME = "format.sh"
+    _SCRIPT_NAME_UNIX = "format.sh"
+    _SCRIPT_NAME_WINDOWS = "format.bat"
 
     def run(self, project_root: Path) -> None:
-        script_path = project_root / self._SCRIPT_NAME
+        is_windows = platform.system() == "Windows"
+
+        if is_windows:
+            self._run_windows_format(project_root)
+        else:
+            self._run_unix_format(project_root)
+
+    def _run_windows_format(self, project_root: Path) -> None:
+        script_sh = project_root / self._SCRIPT_NAME_UNIX
+        script_bat = project_root / self._SCRIPT_NAME_WINDOWS
+
+        has_sh = script_sh.exists() and script_sh.is_file()
+        has_bat = script_bat.exists() and script_bat.is_file()
+
+        if not has_sh and not has_bat:
+            log.info("No format.sh or format.bat found at project root — skipping formatting")
+            return
+
+        # Prefer .bat on Windows, but try .sh if bash is available
+        if has_bat:
+            self._execute_windows_batch(script_bat, project_root)
+        elif has_sh:
+            self._handle_sh_on_windows(script_sh, project_root)
+
+    def _handle_sh_on_windows(self, script_sh: Path, project_root: Path) -> None:
+        bash_path = shutil.which("bash")
+        if bash_path:
+            log.info("format.bat not found, but bash is available. Attempting to run format.sh")
+            self._execute_with_bash(script_sh, project_root, bash_path)
+        else:
+            log.error(
+                "format.bat not found and bash is not available in PATH. "
+                "Please install Git for Windows or ensure format.bat exists."
+            )
+            raise RuntimeError(
+                "Cannot execute format.sh without bash. "
+                "Install Git for Windows or provide format.bat"
+            )
+
+    def _run_unix_format(self, project_root: Path) -> None:
+        script_path = project_root / self._SCRIPT_NAME_UNIX
 
         if not script_path.exists():
             log.info("No format.sh found at project root — skipping formatting")
@@ -32,32 +73,53 @@ class FormatScriptRunner:
         if not script_path.is_file():
             raise RuntimeError("format.sh exists but is not a file")
 
-        if not script_path.is_relative_to(project_root):
+        if not script_path.resolve().is_relative_to(project_root):
             raise RuntimeError("Refusing to execute format.sh outside project root")
 
-        is_windows = platform.system() == "Windows"
-
-        if not is_windows and not script_path.stat().st_mode & 0o111:
+        if not script_path.stat().st_mode & 0o111:
             raise RuntimeError("format.sh is not executable")
 
         log.info("Running project formatter: %s", script_path)
 
         try:
-            if is_windows:
-                bash_path = shutil.which("bash")
-                if not bash_path:
-                    raise RuntimeError("bash not found in PATH")
-                subprocess.run(  # noqa: S603
-                    [bash_path, str(script_path)],
-                    cwd=project_root,
-                    check=True,
-                )
-            else:
-                subprocess.run(  # noqa: S603
-                    [str(script_path)],
-                    cwd=project_root,
-                    check=True,
-                )
+            subprocess.run(  # noqa: S603
+                [str(script_path)],
+                cwd=project_root,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            log.exception("format.sh failed with exit code %s", exc.returncode)
+            raise RuntimeError("Project formatting failed") from exc
+
+    def _execute_windows_batch(self, script_path: Path, project_root: Path) -> None:
+        if not script_path.resolve().is_relative_to(project_root):
+            raise RuntimeError("Refusing to execute format.bat outside project root")
+
+        log.info("Running project formatter: %s", script_path)
+
+        try:
+            cmd_path = shutil.which("cmd") or "cmd.exe"
+            subprocess.run(  # noqa: S603
+                [cmd_path, "/c", str(script_path)],
+                cwd=project_root,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            log.exception("format.bat failed with exit code %s", exc.returncode)
+            raise RuntimeError("Project formatting failed") from exc
+
+    def _execute_with_bash(self, script_path: Path, project_root: Path, bash_path: str) -> None:
+        if not script_path.resolve().is_relative_to(project_root):
+            raise RuntimeError("Refusing to execute format.sh outside project root")
+
+        log.info("Running project formatter with bash: %s", script_path)
+
+        try:
+            subprocess.run(  # noqa: S603
+                [bash_path, str(script_path)],
+                cwd=project_root,
+                check=True,
+            )
         except subprocess.CalledProcessError as exc:
             log.exception("format.sh failed with exit code %s", exc.returncode)
             raise RuntimeError("Project formatting failed") from exc

--- a/src/ar_infra/logger.py
+++ b/src/ar_infra/logger.py
@@ -1,25 +1,35 @@
-"""Logger configuration for AR-INFRA CLI."""
-
 import logging
+import sys
+from typing import ClassVar
 
 
-def get_logger(name: str) -> logging.Logger:
-    """Get or create a configured logger instance.
+class _ColorFormatter(logging.Formatter):
+    COLORS: ClassVar[dict[int, str]] = {
+        logging.DEBUG: "\033[90m",  # gray
+        logging.INFO: "\033[34m",  # blue
+        logging.WARNING: "\033[33m",  # yellow
+        logging.ERROR: "\033[31m",  # red
+        logging.CRITICAL: "\033[31m",  # red
+    }
+    RESET: ClassVar[str] = "\033[0m"
 
-    Creates a logger with INFO level and console output formatting.
-    If the logger already has handlers, returns it as-is to avoid duplicate handlers.
+    def format(self, record: logging.LogRecord) -> str:
+        color = self.COLORS.get(record.levelno, "")
+        level = f"{color}[{record.levelname}]{self.RESET}"
+        message = record.getMessage()
+        return f"{level} {message}"
 
-    Args:
-        name: Name for the logger, typically __name__ of the calling module
 
-    Returns:
-        Configured logging.Logger instance
-    """
-    logger = logging.getLogger(name)
+def get_logger(_: str) -> logging.Logger:
+    logger = logging.getLogger("ar-infra-cli")
+
     if not logger.handlers:
         logger.setLevel(logging.INFO)
-        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
+
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(_ColorFormatter())
+
         logger.addHandler(handler)
+        logger.propagate = False
+
     return logger

--- a/tests/unit/infrastructure/test_format_script_runner.py
+++ b/tests/unit/infrastructure/test_format_script_runner.py
@@ -1,5 +1,6 @@
 """Tests for FormatScriptRunner."""
 
+import platform
 import re
 import subprocess
 from unittest.mock import patch
@@ -55,6 +56,10 @@ class TestFormatScriptRunner:
 
             mock_run.assert_not_called()
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Unix executable permission checks don't work on Windows",
+    )
     @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
     def test_unix_format_raises_when_script_not_executable(
         self, runner, mock_project_root, system_name
@@ -64,9 +69,12 @@ class TestFormatScriptRunner:
 
         with (
             patch("platform.system", return_value=system_name),
+            patch("subprocess.run") as mock_run,
             pytest.raises(RuntimeError, match=re.escape("format.sh is not executable")),
         ):
             runner.run(mock_project_root)
+
+        mock_run.assert_not_called()
 
     @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
     def test_unix_format_raises_when_script_is_directory(

--- a/tests/unit/infrastructure/test_format_script_runner.py
+++ b/tests/unit/infrastructure/test_format_script_runner.py
@@ -1,0 +1,360 @@
+"""Tests for FormatScriptRunner."""
+
+import re
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from src.ar_infra.infrastructure.processor.format_script_runner import (
+    FormatScriptRunner,
+)
+
+
+class TestFormatScriptRunner:
+    @pytest.fixture
+    def runner(self):
+        return FormatScriptRunner()
+
+    @pytest.fixture
+    def mock_project_root(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir(parents=True)
+        return project_root
+
+    # -------------------------------------------------------------------
+    # Unix/Linux/macOS Tests
+    # -------------------------------------------------------------------
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_executes_when_script_exists_and_executable(
+        self, runner, mock_project_root, system_name
+    ):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch(mode=0o755)
+
+        with (
+            patch("platform.system", return_value=system_name),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            mock_run.assert_called_once_with(
+                [str(script_path)],
+                cwd=mock_project_root,
+                check=True,
+            )
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_skips_when_script_missing(self, runner, mock_project_root, system_name):
+        with (
+            patch("platform.system", return_value=system_name),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_raises_when_script_not_executable(
+        self, runner, mock_project_root, system_name
+    ):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch(mode=0o644)  # Not executable
+
+        with (
+            patch("platform.system", return_value=system_name),
+            pytest.raises(RuntimeError, match=re.escape("format.sh is not executable")),
+        ):
+            runner.run(mock_project_root)
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_raises_when_script_is_directory(
+        self, runner, mock_project_root, system_name
+    ):
+        (mock_project_root / "format.sh").mkdir()
+
+        with (
+            patch("platform.system", return_value=system_name),
+            pytest.raises(RuntimeError, match=re.escape("format.sh exists but is not a file")),
+        ):
+            runner.run(mock_project_root)
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_raises_when_script_fails(self, runner, mock_project_root, system_name):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch(mode=0o755)
+
+        with (
+            patch("platform.system", return_value=system_name),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "format.sh"),
+            ),
+            pytest.raises(RuntimeError, match=re.escape("Project formatting failed")),
+        ):
+            runner.run(mock_project_root)
+
+    @pytest.mark.parametrize("system_name", ["Linux", "Darwin"])
+    def test_unix_format_refuses_script_outside_project_root(self, runner, tmp_path, system_name):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        outside_script = tmp_path / "outside" / "format.sh"
+        outside_script.parent.mkdir()
+        outside_script.touch(mode=0o755)
+
+        # Create symlink inside project pointing to outside script
+        script_link = project_root / "format.sh"
+        script_link.symlink_to(outside_script)
+
+        # Verify the test setup: symlink should resolve outside project root
+        assert script_link.resolve() == outside_script
+        assert not script_link.resolve().is_relative_to(project_root)
+
+        with (
+            patch("platform.system", return_value=system_name),
+            pytest.raises(
+                RuntimeError, match=re.escape("Refusing to execute format.sh outside project root")
+            ),
+        ):
+            runner.run(project_root)
+
+    # -------------------------------------------------------------------
+    # Windows Tests - Batch File (.bat)
+    # -------------------------------------------------------------------
+
+    def test_windows_executes_bat_when_available(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.bat"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="cmd.exe"),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            mock_run.assert_called_once_with(
+                ["cmd.exe", "/c", str(script_path)],
+                cwd=mock_project_root,
+                check=True,
+            )
+
+    def test_windows_prefers_bat_over_sh_when_both_exist(self, runner, mock_project_root):
+        bat_path = mock_project_root / "format.bat"
+        sh_path = mock_project_root / "format.sh"
+        bat_path.touch()
+        sh_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="cmd.exe"),  # Return cmd.exe for which("cmd")
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            # Should call bat, not sh
+            mock_run.assert_called_once_with(
+                ["cmd.exe", "/c", str(bat_path)],
+                cwd=mock_project_root,
+                check=True,
+            )
+
+    def test_windows_bat_raises_when_execution_fails(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.bat"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="cmd.exe"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "format.bat"),
+            ),
+            pytest.raises(RuntimeError, match=re.escape("Project formatting failed")),
+        ):
+            runner.run(mock_project_root)
+
+    def test_windows_bat_refuses_script_outside_project_root(self, runner, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        outside_script = tmp_path / "outside" / "format.bat"
+        outside_script.parent.mkdir()
+        outside_script.touch()
+
+        script_link = project_root / "format.bat"
+        script_link.symlink_to(outside_script)
+
+        assert not script_link.resolve().is_relative_to(project_root)
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="cmd.exe"),
+            pytest.raises(
+                RuntimeError,
+                match=re.escape("Refusing to execute format.bat outside project root"),
+            ),
+        ):
+            runner.run(project_root)
+
+    # -------------------------------------------------------------------
+    # Windows Tests - Bash Script (.sh) with Bash Available
+    # -------------------------------------------------------------------
+
+    def test_windows_executes_sh_with_bash_when_bat_unavailable(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="/usr/bin/bash"),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            mock_run.assert_called_once_with(
+                ["/usr/bin/bash", str(script_path)],
+                cwd=mock_project_root,
+                check=True,
+            )
+
+    def test_windows_sh_with_bash_raises_when_execution_fails(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="/usr/bin/bash"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "format.sh"),
+            ),
+            pytest.raises(RuntimeError, match=re.escape("Project formatting failed")),
+        ):
+            runner.run(mock_project_root)
+
+    def test_windows_bash_refuses_script_outside_project_root(self, runner, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        outside_script = tmp_path / "outside" / "format.sh"
+        outside_script.parent.mkdir()
+        outside_script.touch()
+
+        # Create symlink inside project pointing to outside script
+        script_link = project_root / "format.sh"
+        script_link.symlink_to(outside_script)
+
+        assert not script_link.resolve().is_relative_to(project_root)
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value="/usr/bin/bash"),
+            pytest.raises(
+                RuntimeError, match=re.escape("Refusing to execute format.sh outside project root")
+            ),
+        ):
+            runner.run(project_root)
+
+    # -------------------------------------------------------------------
+    # Windows Tests - No Bash Available
+    # -------------------------------------------------------------------
+
+    def test_windows_raises_when_only_sh_exists_and_no_bash(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value=None),  # bash not available
+            pytest.raises(RuntimeError, match=re.escape("Cannot execute format.sh without bash")),
+        ):
+            runner.run(mock_project_root)
+
+    def test_windows_skips_when_no_scripts_exist(self, runner, mock_project_root):
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            mock_run.assert_not_called()
+
+    # -------------------------------------------------------------------
+    # Edge Cases and Integration Tests
+    # -------------------------------------------------------------------
+
+    def test_windows_checks_bat_existence_before_sh(self, runner, mock_project_root):
+        sh_path = mock_project_root / "format.sh"
+        sh_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which") as mock_which,
+            patch("subprocess.run") as mock_run,
+        ):
+            # Bash is available, so .sh should be executed
+            mock_which.return_value = "/usr/bin/bash"
+            runner.run(mock_project_root)
+
+            # which() should have been called to check for bash
+            mock_which.assert_called_once_with("bash")
+
+            # subprocess should execute with bash
+            mock_run.assert_called_once_with(
+                ["/usr/bin/bash", str(sh_path)],
+                cwd=mock_project_root,
+                check=True,
+            )
+
+    @pytest.mark.parametrize(
+        ("system_name", "script_name", "expected_called"),
+        [
+            ("Linux", "format.sh", True),
+            ("Darwin", "format.sh", True),
+            ("Windows", "format.bat", True),
+            ("Windows", "format.sh", True),  # with bash available
+        ],
+    )
+    def test_cross_platform_script_execution(
+        self, runner, mock_project_root, system_name, script_name, expected_called
+    ):
+        script_path = mock_project_root / script_name
+
+        if script_name.endswith(".sh"):
+            script_path.touch(mode=0o755)
+        else:
+            script_path.touch()
+
+        which_return = None
+        if system_name == "Windows":
+            which_return = "cmd.exe" if script_name.endswith(".bat") else "/usr/bin/bash"
+
+        with (
+            patch("platform.system", return_value=system_name),
+            patch("shutil.which", return_value=which_return),
+            patch("subprocess.run") as mock_run,
+        ):
+            runner.run(mock_project_root)
+
+            if expected_called:
+                assert mock_run.call_count == 1
+            else:
+                mock_run.assert_not_called()
+
+    def test_error_message_includes_helpful_context(self, runner, mock_project_root):
+        script_path = mock_project_root / "format.sh"
+        script_path.touch()
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("shutil.which", return_value=None),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            runner.run(mock_project_root)
+
+        error_message = str(exc_info.value)
+        assert "bash" in error_message.lower()
+        assert "format.sh" in error_message.lower()


### PR DESCRIPTION
### Problem:
 some windows system only runs `cmd` and not `bash` interpreter => the `ar-infra init` command fails.
### Solution:
update the `FormatScriptRunner` to handle `format.bat` for `cmd` interpreter.