### PR TITLE
refactor: remove import statement handling from facadeit_handler.py

### DIFF
--- a/src/ar_infra/infrastructure/template/facadeit_handler.py
+++ b/src/ar_infra/infrastructure/template/facadeit_handler.py
@@ -35,13 +35,13 @@ class FacadeITHandler:
             token for feature in disabled_features for token in self._FEATURE_CONF_MAPPING[feature]
         }
 
-        lines = facade_path.read_text(encoding="utf-8").splitlines()
-        filtered = self._remove_disabled_feature_lines(lines, disabled_tokens)
+        content = facade_path.read_text(encoding="utf-8")
+        filtered = self._remove_disabled_feature_lines(content, disabled_tokens)
 
         if not enabled_features:
             filtered = self._remove_empty_before_all(filtered)
 
-        facade_path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
+        facade_path.write_text(filtered, encoding="utf-8")
 
     @staticmethod
     def _find_facade_it(template_dir: Path) -> Path | None:
@@ -54,22 +54,32 @@ class FacadeITHandler:
 
     @staticmethod
     def _remove_disabled_feature_lines(
-        lines: list[str],
+        content: str,
         disabled_tokens: set[str],
-    ) -> list[str]:
+    ) -> str:
+        lines = content.splitlines(keepends=True)
         result: list[str] = []
+        in_import_section = False
 
         for line in lines:
             stripped = line.strip()
-            if any(token in stripped for token in disabled_tokens):
+
+            if stripped.startswith("import "):
+                in_import_section = True
+            elif in_import_section and stripped and not stripped.startswith("import "):
+                in_import_section = False
+
+            if not in_import_section and any(token in stripped for token in disabled_tokens):
                 continue
+
             result.append(line)
 
-        return result
+        return "".join(result)
 
     @staticmethod
-    def _remove_empty_before_all(lines: list[str]) -> list[str]:
-        """Remove @BeforeAll annotated methods from the lines."""
+    def _remove_empty_before_all(content: str) -> str:
+        """Remove @BeforeAll annotated methods from the content."""
+        lines = content.splitlines(keepends=True)
         result: list[str] = []
         i = 0
 
@@ -81,7 +91,7 @@ class FacadeITHandler:
             result.append(lines[i])
             i += 1
 
-        return result
+        return "".join(result)
 
     @staticmethod
     def _skip_before_all_method(lines: list[str], start_index: int) -> int:

--- a/tests/fixtures/sample_FacadeIT.py
+++ b/tests/fixtures/sample_FacadeIT.py
@@ -1,0 +1,91 @@
+FACADE_CONTENT = """
+package com.example.arinfra.conf;
+
+import static java.lang.Runtime.getRuntime;
+
+import com.example.arinfra.InfraGenerated;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Base integration test facade responsible for bootstrapping all infrastructure dependencies
+ * required for end-to-end tests.
+ *
+ * <p>This class starts and manages the lifecycle of the following Testcontainers:
+ *
+ * <ul>
+ *   <li><b>PostgreSQL</b> - persistence layer
+ *   <li><b>RabbitMQ</b> - asynchronous messaging
+ *   <li><b>S3-compatible bucket</b> - file storage
+ *   <li><b>Email service</b> - outbound email testing
+ * </ul>
+ *
+ * <p>Additionally, it dynamically injects environment variables and container connection properties
+ * into the Spring context using {@link DynamicPropertySource}.
+ *
+ * <p><b>Lifecycle guarantees:</b>
+ *
+ * <ul>
+ *   <li>Containers are started once per test JVM
+ *   <li>Containers are stopped gracefully via JVM shutdown hook
+ * </ul>
+ *
+ * <p>This class is marked as {@link InfraGenerated} and must be extended by all integration tests
+ * that require real infrastructure.
+ */
+@Slf4j
+@InfraGenerated
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+public abstract class FacadeIT {
+
+  private static final PostgresConf POSTGRES_CONF = new PostgresConf();
+  private static final RabbitMQConf RABBITMQ_CONF = new RabbitMQConf();
+  private static final BucketConf BUCKET_CONF = new BucketConf();
+  private static final EmailConf EMAIL_CONF = new EmailConf();
+
+  @BeforeAll
+  static void beforeAll() {
+    POSTGRES_CONF.start();
+    RABBITMQ_CONF.start();
+    BUCKET_CONF.start();
+    EMAIL_CONF.start();
+
+    getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  POSTGRES_CONF.stop();
+                  RABBITMQ_CONF.stop();
+                  BUCKET_CONF.stop();
+                  EMAIL_CONF.stop();
+                }));
+  }
+
+  /**
+   * Registers dynamic container and environment properties into the Spring context.
+   *
+   * <p>If {@code EnvConf} is present in the project, it will be loaded reflectively to allow
+   * project-specific environment variables without hard dependency.
+   */
+  @SneakyThrows
+  @DynamicPropertySource
+  static void configureProperties(DynamicPropertyRegistry registry) {
+    POSTGRES_CONF.configureProperties(registry);
+    RABBITMQ_CONF.configureProperties(registry);
+    BUCKET_CONF.configureProperties(registry);
+    EMAIL_CONF.configureProperties(registry);
+
+    Class<?> envConfClazz = EnvConf.class;
+    var configureMethod =
+        envConfClazz.getDeclaredMethod("configureProperties", DynamicPropertyRegistry.class);
+    var envConfInstance = envConfClazz.getConstructor().newInstance();
+    configureMethod.invoke(envConfInstance, registry);
+  }
+}
+""".lstrip()

--- a/tests/unit/infrastructure/test_facadeit_handler.py
+++ b/tests/unit/infrastructure/test_facadeit_handler.py
@@ -3,57 +3,10 @@
 from pathlib import Path
 
 import pytest
+from tests.fixtures.sample_FacadeIT import FACADE_CONTENT
 
 from src.ar_infra.domain.enums.template_feature import TemplateFeature
 from src.ar_infra.infrastructure.template.facadeit_handler import FacadeITHandler
-
-
-FACADE_CONTENT = """
-@Slf4j
-@InfraGenerated
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc(addFilters = false)
-public abstract class FacadeIT {
-
-  private static final PostgresConf POSTGRES_CONF = new PostgresConf();
-  private static final RabbitMQConf RABBITMQ_CONF = new RabbitMQConf();
-  private static final BucketConf BUCKET_CONF = new BucketConf();
-  private static final EmailConf EMAIL_CONF = new EmailConf();
-
-  @BeforeAll
-  static void beforeAll() {
-    POSTGRES_CONF.start();
-    RABBITMQ_CONF.start();
-    BUCKET_CONF.start();
-    EMAIL_CONF.start();
-
-    getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  POSTGRES_CONF.stop();
-                  RABBITMQ_CONF.stop();
-                  BUCKET_CONF.stop();
-                  EMAIL_CONF.stop();
-                }));
-  }
-
-  @SneakyThrows
-  @DynamicPropertySource
-  static void configureProperties(DynamicPropertyRegistry registry) {
-    POSTGRES_CONF.configureProperties(registry);
-    RABBITMQ_CONF.configureProperties(registry);
-    BUCKET_CONF.configureProperties(registry);
-    EMAIL_CONF.configureProperties(registry);
-
-    Class<?> envConfClazz = EnvConf.class;
-    var configureMethod =
-        envConfClazz.getDeclaredMethod("configureProperties", DynamicPropertyRegistry.class);
-    var envConfInstance = envConfClazz.getConstructor().newInstance();
-    configureMethod.invoke(envConfInstance, registry);
-  }
-}
-""".lstrip()
 
 
 class TestFacadeITHandler:
@@ -76,10 +29,10 @@ class TestFacadeITHandler:
 
         content = self._read(facade_path)
 
-        assert "PostgresConf" in content
-        assert "RabbitMQConf" not in content
-        assert "BucketConf" not in content
-        assert "EmailConf" not in content
+        assert "POSTGRES_CONF" in content
+        assert "RABBITMQ_CONF" not in content
+        assert "BUCKET_CONF" not in content
+        assert "EMAIL_CONF" not in content
 
     def test_multiple_features_enabled(self, facade_path: Path) -> None:
         FacadeITHandler().apply_feature_selection(
@@ -89,10 +42,10 @@ class TestFacadeITHandler:
 
         content = self._read(facade_path)
 
-        assert "PostgresConf" in content
-        assert "RabbitMQConf" in content
-        assert "BucketConf" not in content
-        assert "EmailConf" not in content
+        assert "POSTGRES_CONF" in content
+        assert "RABBITMQ_CONF" in content
+        assert "BUCKET_CONF" not in content
+        assert "EMAIL_CONF" not in content
 
     def test_all_features_enabled(self, facade_path: Path) -> None:
         FacadeITHandler().apply_feature_selection(
@@ -102,10 +55,10 @@ class TestFacadeITHandler:
 
         content = self._read(facade_path)
 
-        assert "PostgresConf" in content
-        assert "RabbitMQConf" in content
-        assert "BucketConf" in content
-        assert "EmailConf" in content
+        assert "POSTGRES_CONF" in content
+        assert "RABBITMQ_CONF" in content
+        assert "BUCKET_CONF" in content
+        assert "EMAIL_CONF" in content
 
     def test_before_all_removed_when_no_features_enabled(self, facade_path: Path) -> None:
         FacadeITHandler().apply_feature_selection(
@@ -126,10 +79,10 @@ class TestFacadeITHandler:
 
         content = self._read(facade_path)
 
-        assert "PostgresConf" not in content
-        assert "RabbitMQConf" not in content
-        assert "BucketConf" not in content
-        assert "EmailConf" not in content
+        assert "POSTGRES_CONF" not in content
+        assert "RABBITMQ_CONF" not in content
+        assert "BUCKET_CONF" not in content
+        assert "EMAIL_CONF" not in content
         assert "class FacadeIT" in content
 
     def test_idempotency(self, facade_path: Path) -> None:
@@ -176,3 +129,17 @@ class TestFacadeITHandler:
 
         content = self._read(facade_path)
         assert content.strip() != ""
+
+    def test_standard_imports_preserved(self, facade_path: Path) -> None:
+        FacadeITHandler().apply_feature_selection(
+            facade_path.parents[5],
+            set(),
+        )
+
+        content = self._read(facade_path)
+
+        assert "import static java.lang.Runtime.getRuntime;" in content
+        assert "import com.example.arinfra.InfraGenerated;" in content
+        assert "import lombok.SneakyThrows;" in content
+        assert "import lombok.extern.slf4j.Slf4j;" in content
+        assert "import org.springframework.test.context.DynamicPropertySource;" in content


### PR DESCRIPTION
The `FacadeITHandler` was trying to handle the removal of the import that are related to the selected feature. But this is a job handled by the `FormatScriptRunner` already.
Therefore, we remove that logic from `FacadeITHandler`