### PR TITLE
Handle doc/api.yaml according to selected features

### DIFF
--- a/src/ar_infra/infrastructure/template/feature_manager.py
+++ b/src/ar_infra/infrastructure/template/feature_manager.py
@@ -6,6 +6,7 @@ from src.ar_infra.infrastructure.template.env_handler import EnvHandler
 from src.ar_infra.infrastructure.template.facadeit_handler import FacadeITHandler
 from src.ar_infra.infrastructure.template.feature_config import FEATURE_MAPPINGS
 from src.ar_infra.infrastructure.template.rest_exception_manager import RestExceptionHandlerManager
+from src.ar_infra.infrastructure.template.swagger_handler import SwaggerHandler
 
 
 class FeatureManager:
@@ -14,10 +15,12 @@ class FeatureManager:
         env_handler: EnvHandler | None = None,
         facadeit_handler: FacadeITHandler | None = None,
         rest_exception_handler: RestExceptionHandlerManager | None = None,
+        swagger_handler: SwaggerHandler | None = None,
     ) -> None:
         self._env_handler = env_handler or EnvHandler()
         self._facadeit_handler = facadeit_handler or FacadeITHandler()
         self._rest_exception_handler = rest_exception_handler or RestExceptionHandlerManager()
+        self._swagger_handler = swagger_handler
 
     def apply_feature_selection(
         self,
@@ -34,10 +37,9 @@ class FeatureManager:
             template_dir,
             enabled_features,
         )
-
         self._rest_exception_handler.apply_feature_selection(template_dir, enabled_features)
-
         self._remove_env_variables_for_disabled_features(template_dir, features_to_remove)
+        self._update_swagger_documentation(template_dir, enabled_features)
 
     @staticmethod
     def remove_feature(
@@ -84,3 +86,13 @@ class FeatureManager:
         self._env_handler.remove_feature_env_variables(
             env_file, features_to_remove, env_variable_mappings
         )
+
+    def _update_swagger_documentation(
+        self,
+        template_dir: Path,
+        enabled_features: set[TemplateFeature],
+    ) -> None:
+        api_file = template_dir / "doc" / "api.yml"
+
+        swagger_handler = self._swagger_handler or SwaggerHandler(api_file)
+        swagger_handler.update_swagger(enabled_features)

--- a/src/ar_infra/infrastructure/template/feature_manager.py
+++ b/src/ar_infra/infrastructure/template/feature_manager.py
@@ -92,7 +92,7 @@ class FeatureManager:
         template_dir: Path,
         enabled_features: set[TemplateFeature],
     ) -> None:
-        api_file = template_dir / "doc" / "api.yml"
+        api_file = template_dir / "doc" / "api.yaml"
 
         swagger_handler = self._swagger_handler or SwaggerHandler(api_file)
         swagger_handler.update_swagger(enabled_features)

--- a/src/ar_infra/infrastructure/template/swagger_handler.py
+++ b/src/ar_infra/infrastructure/template/swagger_handler.py
@@ -6,6 +6,10 @@ from typing import Any, ClassVar
 import yaml
 
 from src.ar_infra.domain.enums.template_feature import TemplateFeature
+from src.ar_infra.logger import get_logger
+
+
+log = get_logger(use_rich=True)
 
 
 class SwaggerHandler:
@@ -18,22 +22,60 @@ class SwaggerHandler:
 
     def __init__(self, api_file_path: Path) -> None:
         self.api_file_path = api_file_path
+        log.debug("Initialized SwaggerHandler with api_file_path: %s", api_file_path)
 
     def update_swagger(self, selected_features: set[TemplateFeature]) -> None:
+        log.info(
+            "Updating Swagger documentation with selected features: %s",
+            [f.value for f in selected_features],
+        )
+
         if not self.api_file_path.exists():
+            log.warning("API file does not exist: %s", self.api_file_path)
             return
 
+        swagger_data = self._load_swagger_data()
+        if swagger_data is None:
+            return
+
+        endpoints_to_remove = self._get_endpoints_to_remove(selected_features)
+        self._log_removal_summary(endpoints_to_remove)
+        self._remove_endpoints(swagger_data, endpoints_to_remove)
+        self._save_swagger_data(swagger_data)
+
+        log.info("Swagger documentation updated successfully")
+
+    def _load_swagger_data(self) -> dict[str, Any] | None:
+        log.debug("Loading Swagger file from: %s", self.api_file_path)
         with self.api_file_path.open("r", encoding="utf-8") as f:
             swagger_data: dict[str, Any] = yaml.safe_load(f)
 
         if "paths" not in swagger_data:
-            return
+            log.warning("Swagger file does not contain 'paths' key, skipping update")
+            return None
 
-        endpoints_to_remove = self._get_endpoints_to_remove(selected_features)
+        return swagger_data
 
+    @staticmethod
+    def _log_removal_summary(endpoints_to_remove: set[str]) -> None:
+        if endpoints_to_remove:
+            log.info(
+                "Removing %d unused health endpoints: %s",
+                len(endpoints_to_remove),
+                endpoints_to_remove,
+            )
+        else:
+            log.info("No endpoints to remove, all features are selected")
+
+    @staticmethod
+    def _remove_endpoints(swagger_data: dict[str, Any], endpoints_to_remove: set[str]) -> None:
         for endpoint in endpoints_to_remove:
-            swagger_data["paths"].pop(endpoint, None)
+            if endpoint in swagger_data["paths"]:
+                log.debug("Removing endpoint: %s", endpoint)
+                swagger_data["paths"].pop(endpoint, None)
 
+    def _save_swagger_data(self, swagger_data: dict[str, Any]) -> None:
+        log.debug("Writing updated Swagger file to: %s", self.api_file_path)
         with self.api_file_path.open("w", encoding="utf-8") as f:
             yaml.safe_dump(
                 swagger_data,
@@ -50,4 +92,7 @@ class SwaggerHandler:
             if feature not in selected_features:
                 endpoints_to_remove.add(endpoint)
 
+        log.debug(
+            "Identified %d endpoints to remove based on feature selection", len(endpoints_to_remove)
+        )
         return endpoints_to_remove

--- a/src/ar_infra/infrastructure/template/swagger_handler.py
+++ b/src/ar_infra/infrastructure/template/swagger_handler.py
@@ -1,0 +1,53 @@
+"""Handler for updating OpenAPI/Swagger documentation based on selected features."""
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import yaml
+
+from src.ar_infra.domain.enums.template_feature import TemplateFeature
+
+
+class SwaggerHandler:
+    FEATURE_ENDPOINTS: ClassVar[dict[TemplateFeature, str]] = {
+        TemplateFeature.POSTGRESQL: "/health/db",
+        TemplateFeature.RABBITMQ: "/health/message",
+        TemplateFeature.S3_BUCKET: "/health/bucket",
+        TemplateFeature.EMAIL: "/health/email",
+    }
+
+    def __init__(self, api_file_path: Path) -> None:
+        self.api_file_path = api_file_path
+
+    def update_swagger(self, selected_features: set[TemplateFeature]) -> None:
+        if not self.api_file_path.exists():
+            return
+
+        with self.api_file_path.open("r", encoding="utf-8") as f:
+            swagger_data: dict[str, Any] = yaml.safe_load(f)
+
+        if "paths" not in swagger_data:
+            return
+
+        endpoints_to_remove = self._get_endpoints_to_remove(selected_features)
+
+        for endpoint in endpoints_to_remove:
+            swagger_data["paths"].pop(endpoint, None)
+
+        with self.api_file_path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(
+                swagger_data,
+                f,
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+
+    def _get_endpoints_to_remove(self, selected_features: set[TemplateFeature]) -> set[str]:
+        endpoints_to_remove = set()
+
+        for feature, endpoint in self.FEATURE_ENDPOINTS.items():
+            if feature not in selected_features:
+                endpoints_to_remove.add(endpoint)
+
+        return endpoints_to_remove

--- a/tests/fixtures/sample_swagger_api.py
+++ b/tests/fixtures/sample_swagger_api.py
@@ -1,84 +1,267 @@
-SAMPLE_SWAGGER_API = {
-    "openapi": "3.1.0",
-    "info": {"title": "Title", "description": "Title", "version": "1.0.0"},
-    "servers": [{"url": "https"}],
-    "paths": {
-        "/": {
-            "get": {
-                "operationId": "rootRedirect",
-                "tags": ["Docs"],
-                "summary": "Redirect root path to Swagger UI",
-                "responses": {
-                    "302": {
-                        "description": "Redirects to /doc",
-                        "headers": {
-                            "Location": {
-                                "description": "URL to redirect",
-                                "schema": {
-                                    "type": "string",
-                                    "example": "/doc",
-                                },
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/ping": {
-            "get": {
-                "operationId": "pong",
-                "tags": ["Health"],
-                "summary": "Check if the server is alive",
-                "responses": {
-                    "200": {
-                        "description": "A message showing that the server is alive",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string",
-                                    "example": "pong",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/health/bucket": {
-            "get": {
-                "operationId": "healthBucketCheck",
-                "tags": ["Health"],
-                "summary": "Check bucket health",
-            }
-        },
-        "/health/email": {
-            "get": {
-                "operationId": "sendHealthEmail",
-                "tags": ["Health"],
-                "summary": "Send health check email",
-            }
-        },
-        "/health/message": {
-            "get": {
-                "operationId": "triggerDummyEvents",
-                "tags": ["Health"],
-                "summary": "Trigger dummy health check events",
-            }
-        },
-        "/health/db": {
-            "get": {
-                "operationId": "healthDbCheck",
-                "tags": ["Health"],
-                "summary": "Health check for the database",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ErrorResponse": {"type": "object"},
-            "DateTime": {"type": "string"},
-            "UUID": {"type": "string"},
-            "Dummy": {"type": "object"},
-        }
-    },
-}
+SAMPLE_SWAGGER_API_YAML = """
+openapi: 3.1.0
+info:
+  title: Title
+  description: Title
+  version: 1.0.0
+servers:
+  - url: 'https'
+paths:
+  /:
+    get:
+      operationId: rootRedirect
+      tags:
+        - Docs
+      summary: Redirect root path to Swagger UI
+      responses:
+        302:
+          description: Redirects to /doc
+          headers:
+            Location:
+              description: URL to redirect
+              schema:
+                type: string
+                example: /doc
+  /ping:
+    get:
+      operationId: pong
+      tags:
+        - Health
+      summary: Check if the server is alive
+      responses:
+        200:
+          description: A message showing that the server is alive
+          content:
+            application/json:
+              schema:
+                type: string
+                example: pong
+  /health/bucket:
+    get:
+      operationId: healthBucketCheck
+      tags:
+        - Health
+      summary: Check bucket health by uploading, downloading, and presigning a file
+      description: >
+        This endpoint uploads a randomly generated text file to the storage bucket,  verifies its content by downloading it, and returns a presigned URL for the file.
+
+      responses:
+        200:
+          description: Successfully uploaded, verified, and presigned file.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "https://unfaked-bucket.s3.amazonaws.com/health/uuid.txt?X-Amz-Signature=..."
+        500:
+          description: Uploaded and downloaded content mismatch or other error occurred.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Uploaded and downloaded content mismatch
+  /health/email:
+    get:
+      operationId: sendHealthEmail
+      tags:
+        - Health
+      summary: Send health check email
+      description: Sends a test email to verify email service functionality
+      security: []
+      parameters:
+        - name: to
+          in: query
+          required: true
+          description: Email address to send the health check email to
+          schema:
+            type: string
+            format: email
+      responses:
+        "200":
+          description: Email sent successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Email sent successfully"
+        "400":
+          description: Invalid email address format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                timestamp: "2025-11-04T10:30:00Z"
+                status: 400
+                error: "Bad Request"
+                message: "Invalid email address format"
+                path: "/health/email"
+                errorCode: "BAD_FORM"
+  /health/message:
+    get:
+      operationId: triggerDummyEvents
+      tags:
+        - Health
+      summary: Trigger dummy health check events
+      description: >
+        This endpoint triggers one or more dummy events through the event producer  for testing the messaging system (e.g., RabbitMQ or Kafka).
+
+      parameters:
+        - name: nbEvent
+          in: query
+          required: false
+          description: Number of events to trigger (1-500)
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+            maximum: 500
+        - name: waitInSeconds
+          in: query
+          required: false
+          description: Duration (in seconds) to simulate event processing
+          schema:
+            type: integer
+            default: 2
+            minimum: 1
+      responses:
+        200:
+          description: List of UUIDs corresponding to triggered dummy events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example:
+                  - "c91f2c9b-9c8e-4e7f-84e2-09c95edff3e4"
+                  - "51af4d2b-745a-465d-b9a2-bf0b1c1ffb23"
+        400:
+          description: Invalid parameter values (e.g., nbEvent not in 1-500)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: nbEvent must be between 1 and 500
+  /health/db:
+    get:
+      summary: Health check for the dummy database
+      description: Returns a paginated list of Dummy entities.
+      tags:
+        - Health
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 0
+          description: Page number (0-based)
+        - in: query
+          name: size
+          schema:
+            type: integer
+            default: 10
+          description: Page size
+      responses:
+        "200":
+          description: Successful database health check
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Dummy"
+                  totalElements:
+                    type: integer
+                  totalPages:
+                    type: integer
+                  number:
+                    type: integer
+                  size:
+                    type: integer
+                example:
+                  content:
+                    - id: "550e8400-e29b-41d4-a716-446655440000"
+                      description: "First dummy description"
+                  totalElements: 5
+                  totalPages: 1
+                  number: 0
+                  size: 5
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        timestamp:
+          $ref: "#/components/schemas/DateTime"
+          description: When the error occurred
+        status:
+          type: integer
+          description: HTTP status code
+          example: 400
+        error:
+          type: string
+          description: HTTP status reason phrase
+          example: "Bad Request"
+        message:
+          type: string
+          description: Detailed error message
+          example: "Validation failed"
+        path:
+          type: string
+          description: Request path where error occurred
+          example: "/path/of/the/endpoint"
+        errorCode:
+          type: string
+          description: Application-specific error code
+          enum:
+            - AUTHORIZATION_DENIED
+            - ENTITY_NOT_FOUND
+            - CONSTRAINT_VIOLATION_ON_FIELDS
+            - TOKEN_UNIQUENESS_CONFLICT
+            - BAD_FORM
+            - MISSING_AUTHORIZATION
+            - INVALID_AUTHORIZATION_FORMAT
+            - INVALID_TOKEN
+            - TOKEN_NOT_FOUND
+            - USER_DEACTIVATED
+            - AUTHENTICATION_FAILED
+            - INTERNAL_SERVER_ERROR
+            - MISSING_REQUIRED_PARAMETER
+            - INVALID_PARAMETER
+            - MALFORMED_JSON
+            - METHOD_NOT_ALLOWED
+      required:
+        - timestamp
+        - status
+        - error
+        - message
+        - path
+    DateTime:
+      type: string
+      format: date-time
+      description: 'Date and time in ISO 8601 format (RFC 3339)'
+      example: '2025-12-06T11:23:45Z'
+    UUID:
+      type: string
+      pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+      format: uuid
+      example: e6b5cc3e-eaaa-4cb3-912c-e059e983bb78
+    Dummy:
+      type: object
+      required: [id, description]
+      properties:
+        id:
+          $ref: "#/components/schemas/UUID"
+        description:
+          type: string
+"""

--- a/tests/fixtures/sample_swagger_api.py
+++ b/tests/fixtures/sample_swagger_api.py
@@ -1,0 +1,84 @@
+SAMPLE_SWAGGER_API = {
+    "openapi": "3.1.0",
+    "info": {"title": "Title", "description": "Title", "version": "1.0.0"},
+    "servers": [{"url": "https"}],
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "rootRedirect",
+                "tags": ["Docs"],
+                "summary": "Redirect root path to Swagger UI",
+                "responses": {
+                    "302": {
+                        "description": "Redirects to /doc",
+                        "headers": {
+                            "Location": {
+                                "description": "URL to redirect",
+                                "schema": {
+                                    "type": "string",
+                                    "example": "/doc",
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/ping": {
+            "get": {
+                "operationId": "pong",
+                "tags": ["Health"],
+                "summary": "Check if the server is alive",
+                "responses": {
+                    "200": {
+                        "description": "A message showing that the server is alive",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "pong",
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/health/bucket": {
+            "get": {
+                "operationId": "healthBucketCheck",
+                "tags": ["Health"],
+                "summary": "Check bucket health",
+            }
+        },
+        "/health/email": {
+            "get": {
+                "operationId": "sendHealthEmail",
+                "tags": ["Health"],
+                "summary": "Send health check email",
+            }
+        },
+        "/health/message": {
+            "get": {
+                "operationId": "triggerDummyEvents",
+                "tags": ["Health"],
+                "summary": "Trigger dummy health check events",
+            }
+        },
+        "/health/db": {
+            "get": {
+                "operationId": "healthDbCheck",
+                "tags": ["Health"],
+                "summary": "Health check for the database",
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "ErrorResponse": {"type": "object"},
+            "DateTime": {"type": "string"},
+            "UUID": {"type": "string"},
+            "Dummy": {"type": "object"},
+        }
+    },
+}

--- a/tests/unit/infrastructure/test_swagger_handler.py
+++ b/tests/unit/infrastructure/test_swagger_handler.py
@@ -3,251 +3,247 @@ from typing import Any
 
 import pytest
 import yaml
-from tests.fixtures.sample_swagger_api import SAMPLE_SWAGGER_API
+from tests.fixtures.sample_swagger_api import SAMPLE_SWAGGER_API_YAML
 
 from src.ar_infra.domain.enums.template_feature import TemplateFeature
 from src.ar_infra.infrastructure.template.swagger_handler import SwaggerHandler
 
 
-@pytest.fixture
-def sample_swagger_data() -> dict[str, Any]:
-    return SAMPLE_SWAGGER_API
+class TestSwaggerHandler:
+    @pytest.fixture
+    def sample_swagger_data(self) -> dict[str, Any]:
+        return yaml.safe_load(SAMPLE_SWAGGER_API_YAML)
 
+    @pytest.fixture
+    def temp_template_dir(self, tmp_path: Path, sample_swagger_data: dict[str, Any]) -> Path:
+        template_dir = tmp_path / "template"
+        doc_dir = template_dir / "doc"
+        doc_dir.mkdir(parents=True)
 
-@pytest.fixture
-def temp_api_file(tmp_path: Path, sample_swagger_data: dict[str, Any]) -> Path:
-    api_file = tmp_path / "api.yml"
-    with api_file.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(sample_swagger_data, f)
-    return api_file
+        api_file = doc_dir / "api.yml"
+        with api_file.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(sample_swagger_data, f)
 
+        return template_dir
 
-def test_update_swagger_all_features_selected(
-    temp_api_file: Path, sample_swagger_data: dict[str, Any]
-) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    all_features = {
-        TemplateFeature.POSTGRESQL,
-        TemplateFeature.RABBITMQ,
-        TemplateFeature.S3_BUCKET,
-        TemplateFeature.EMAIL,
-    }
+    @pytest.fixture
+    def api_file_path(self, temp_template_dir: Path) -> Path:
+        return temp_template_dir / "doc" / "api.yml"
 
-    handler.update_swagger(all_features)
+    def test_update_swagger_all_features_selected(
+        self, api_file_path: Path, sample_swagger_data: dict[str, Any]
+    ) -> None:
+        handler = SwaggerHandler(api_file_path)
+        all_features = {
+            TemplateFeature.POSTGRESQL,
+            TemplateFeature.RABBITMQ,
+            TemplateFeature.S3_BUCKET,
+            TemplateFeature.EMAIL,
+        }
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        handler.update_swagger(all_features)
 
-    assert "/health/db" in result["paths"]
-    assert "/health/message" in result["paths"]
-    assert "/health/bucket" in result["paths"]
-    assert "/health/email" in result["paths"]
-    assert "/" in result["paths"]
-    assert "/ping" in result["paths"]
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    assert result["components"] == sample_swagger_data["components"]
+        assert "/health/db" in result["paths"]
+        assert "/health/message" in result["paths"]
+        assert "/health/bucket" in result["paths"]
+        assert "/health/email" in result["paths"]
+        assert "/" in result["paths"]
+        assert "/ping" in result["paths"]
 
+        assert result["components"] == sample_swagger_data["components"]
 
-def test_update_swagger_no_features_selected(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    no_features: set[TemplateFeature] = set()
+    def test_update_swagger_no_features_selected(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        no_features: set[TemplateFeature] = set()
 
-    handler.update_swagger(no_features)
+        handler.update_swagger(no_features)
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    assert "/health/db" not in result["paths"]
-    assert "/health/message" not in result["paths"]
-    assert "/health/bucket" not in result["paths"]
-    assert "/health/email" not in result["paths"]
+        assert "/health/db" not in result["paths"]
+        assert "/health/message" not in result["paths"]
+        assert "/health/bucket" not in result["paths"]
+        assert "/health/email" not in result["paths"]
 
-    assert "/" in result["paths"]
-    assert "/ping" in result["paths"]
+        assert "/" in result["paths"]
+        assert "/ping" in result["paths"]
 
-    assert "components" in result
-    assert "schemas" in result["components"]
+        assert "components" in result
+        assert "schemas" in result["components"]
 
+    def test_update_swagger_only_postgresql(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.POSTGRESQL}
 
-def test_update_swagger_only_postgresql(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.POSTGRESQL}
+        handler.update_swagger(features)
 
-    handler.update_swagger(features)
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        assert "/health/db" in result["paths"]
+        assert "/health/message" not in result["paths"]
+        assert "/health/bucket" not in result["paths"]
+        assert "/health/email" not in result["paths"]
 
-    assert "/health/db" in result["paths"]
-    assert "/health/message" not in result["paths"]
-    assert "/health/bucket" not in result["paths"]
-    assert "/health/email" not in result["paths"]
+        assert "/" in result["paths"]
+        assert "/ping" in result["paths"]
 
-    assert "/" in result["paths"]
-    assert "/ping" in result["paths"]
+    def test_update_swagger_only_rabbitmq(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.RABBITMQ}
 
+        handler.update_swagger(features)
 
-def test_update_swagger_only_rabbitmq(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.RABBITMQ}
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    handler.update_swagger(features)
+        assert "/health/message" in result["paths"]
+        assert "/health/db" not in result["paths"]
+        assert "/health/bucket" not in result["paths"]
+        assert "/health/email" not in result["paths"]
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+    def test_update_swagger_only_s3_bucket(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.S3_BUCKET}
 
-    assert "/health/message" in result["paths"]
-    assert "/health/db" not in result["paths"]
-    assert "/health/bucket" not in result["paths"]
-    assert "/health/email" not in result["paths"]
+        handler.update_swagger(features)
 
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-def test_update_swagger_only_s3_bucket(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.S3_BUCKET}
+        assert "/health/bucket" in result["paths"]
+        assert "/health/db" not in result["paths"]
+        assert "/health/message" not in result["paths"]
+        assert "/health/email" not in result["paths"]
 
-    handler.update_swagger(features)
+    def test_update_swagger_only_email(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.EMAIL}
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        handler.update_swagger(features)
 
-    assert "/health/bucket" in result["paths"]
-    assert "/health/db" not in result["paths"]
-    assert "/health/message" not in result["paths"]
-    assert "/health/email" not in result["paths"]
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
+        assert "/health/email" in result["paths"]
+        assert "/health/db" not in result["paths"]
+        assert "/health/message" not in result["paths"]
+        assert "/health/bucket" not in result["paths"]
 
-def test_update_swagger_only_email(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.EMAIL}
+    def test_update_swagger_multiple_features(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
 
-    handler.update_swagger(features)
+        handler.update_swagger(features)
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    assert "/health/email" in result["paths"]
-    assert "/health/db" not in result["paths"]
-    assert "/health/message" not in result["paths"]
-    assert "/health/bucket" not in result["paths"]
+        assert "/health/db" in result["paths"]
+        assert "/health/email" in result["paths"]
 
+        assert "/health/message" not in result["paths"]
+        assert "/health/bucket" not in result["paths"]
 
-def test_update_swagger_multiple_features(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
+    def test_update_swagger_file_not_exists(self, tmp_path: Path) -> None:
+        non_existent_file = tmp_path / "doc" / "does_not_exist.yml"
+        handler = SwaggerHandler(non_existent_file)
 
-    handler.update_swagger(features)
+        handler.update_swagger({TemplateFeature.POSTGRESQL})
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        assert not non_existent_file.exists()
 
-    assert "/health/db" in result["paths"]
-    assert "/health/email" in result["paths"]
+    def test_update_swagger_missing_paths_key(self, tmp_path: Path) -> None:
+        doc_dir = tmp_path / "doc"
+        doc_dir.mkdir()
+        api_file = doc_dir / "api.yml"
+        invalid_swagger = {"openapi": "3.1.0", "info": {"title": "Test"}}
 
-    assert "/health/message" not in result["paths"]
-    assert "/health/bucket" not in result["paths"]
+        with api_file.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(invalid_swagger, f)
 
+        handler = SwaggerHandler(api_file)
+        handler.update_swagger({TemplateFeature.POSTGRESQL})
 
-def test_update_swagger_file_not_exists(tmp_path: Path) -> None:
-    non_existent_file = tmp_path / "does_not_exist.yml"
-    handler = SwaggerHandler(non_existent_file)
+        with api_file.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    handler.update_swagger({TemplateFeature.POSTGRESQL})
+        assert result == invalid_swagger
 
-    assert not non_existent_file.exists()
+    def test_update_swagger_preserves_order(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.POSTGRESQL, TemplateFeature.S3_BUCKET}
 
+        handler.update_swagger(features)
 
-def test_update_swagger_missing_paths_key(tmp_path: Path) -> None:
-    api_file = tmp_path / "api.yml"
-    invalid_swagger = {"openapi": "3.1.0", "info": {"title": "Test"}}
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    with api_file.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(invalid_swagger, f)
+        paths_keys = list(result["paths"].keys())
+        assert paths_keys.index("/") < paths_keys.index("/ping")
+        assert "/health/bucket" in paths_keys
+        assert "/health/db" in paths_keys
 
-    handler = SwaggerHandler(api_file)
-    handler.update_swagger({TemplateFeature.POSTGRESQL})
+    def test_update_swagger_components_unchanged(
+        self, api_file_path: Path, sample_swagger_data: dict[str, Any]
+    ) -> None:
+        handler = SwaggerHandler(api_file_path)
+        handler.update_swagger({TemplateFeature.EMAIL})
 
-    with api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    assert result == invalid_swagger
+        assert result["components"] == sample_swagger_data["components"]
+        assert "ErrorResponse" in result["components"]["schemas"]
+        assert "DateTime" in result["components"]["schemas"]
+        assert "UUID" in result["components"]["schemas"]
+        assert "Dummy" in result["components"]["schemas"]
 
+    def test_get_endpoints_to_remove_all_features(self) -> None:
+        handler = SwaggerHandler(Path("dummy.yml"))
+        all_features = {
+            TemplateFeature.POSTGRESQL,
+            TemplateFeature.RABBITMQ,
+            TemplateFeature.S3_BUCKET,
+            TemplateFeature.EMAIL,
+        }
 
-def test_update_swagger_preserves_order(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.POSTGRESQL, TemplateFeature.S3_BUCKET}
+        endpoints = handler._get_endpoints_to_remove(all_features)
 
-    handler.update_swagger(features)
+        assert len(endpoints) == 0
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+    def test_get_endpoints_to_remove_no_features(self) -> None:
+        handler = SwaggerHandler(Path("dummy.yml"))
+        no_features: set[TemplateFeature] = set()
 
-    paths_keys = list(result["paths"].keys())
-    assert paths_keys.index("/") < paths_keys.index("/ping")
-    assert "/health/bucket" in paths_keys
-    assert "/health/db" in paths_keys
+        endpoints = handler._get_endpoints_to_remove(no_features)
 
+        assert endpoints == {
+            "/health/db",
+            "/health/message",
+            "/health/bucket",
+            "/health/email",
+        }
 
-def test_update_swagger_components_unchanged(
-    temp_api_file: Path, sample_swagger_data: dict[str, Any]
-) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    handler.update_swagger({TemplateFeature.EMAIL})
+    def test_get_endpoints_to_remove_partial_features(self) -> None:
+        handler = SwaggerHandler(Path("dummy.yml"))
+        features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
 
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
+        endpoints = handler._get_endpoints_to_remove(features)
 
-    assert result["components"] == sample_swagger_data["components"]
-    assert "ErrorResponse" in result["components"]["schemas"]
-    assert "DateTime" in result["components"]["schemas"]
-    assert "UUID" in result["components"]["schemas"]
-    assert "Dummy" in result["components"]["schemas"]
+        assert endpoints == {"/health/message", "/health/bucket"}
 
+    def test_forward_compatibility_mysql_feature(self, api_file_path: Path) -> None:
+        handler = SwaggerHandler(api_file_path)
+        features = {TemplateFeature.POSTGRESQL}
 
-def test_get_endpoints_to_remove_all_features() -> None:
-    handler = SwaggerHandler(Path("dummy.yml"))
-    all_features = {
-        TemplateFeature.POSTGRESQL,
-        TemplateFeature.RABBITMQ,
-        TemplateFeature.S3_BUCKET,
-        TemplateFeature.EMAIL,
-    }
+        handler.update_swagger(features)
 
-    endpoints = handler._get_endpoints_to_remove(all_features)
+        with api_file_path.open("r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
 
-    assert len(endpoints) == 0
-
-
-def test_get_endpoints_to_remove_no_features() -> None:
-    handler = SwaggerHandler(Path("dummy.yml"))
-    no_features: set[TemplateFeature] = set()
-
-    endpoints = handler._get_endpoints_to_remove(no_features)
-
-    assert endpoints == {
-        "/health/db",
-        "/health/message",
-        "/health/bucket",
-        "/health/email",
-    }
-
-
-def test_get_endpoints_to_remove_partial_features() -> None:
-    handler = SwaggerHandler(Path("dummy.yml"))
-    features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
-
-    endpoints = handler._get_endpoints_to_remove(features)
-
-    assert endpoints == {"/health/message", "/health/bucket"}
-
-
-def test_forward_compatibility_mysql_feature(temp_api_file: Path) -> None:
-    handler = SwaggerHandler(temp_api_file)
-    features = {TemplateFeature.POSTGRESQL}
-
-    handler.update_swagger(features)
-
-    with temp_api_file.open("r", encoding="utf-8") as f:
-        result = yaml.safe_load(f)
-
-    assert "/health/db" in result["paths"]
+        assert "/health/db" in result["paths"]

--- a/tests/unit/infrastructure/test_swagger_handler.py
+++ b/tests/unit/infrastructure/test_swagger_handler.py
@@ -1,0 +1,253 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from tests.fixtures.sample_swagger_api import SAMPLE_SWAGGER_API
+
+from src.ar_infra.domain.enums.template_feature import TemplateFeature
+from src.ar_infra.infrastructure.template.swagger_handler import SwaggerHandler
+
+
+@pytest.fixture
+def sample_swagger_data() -> dict[str, Any]:
+    return SAMPLE_SWAGGER_API
+
+
+@pytest.fixture
+def temp_api_file(tmp_path: Path, sample_swagger_data: dict[str, Any]) -> Path:
+    api_file = tmp_path / "api.yml"
+    with api_file.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(sample_swagger_data, f)
+    return api_file
+
+
+def test_update_swagger_all_features_selected(
+    temp_api_file: Path, sample_swagger_data: dict[str, Any]
+) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    all_features = {
+        TemplateFeature.POSTGRESQL,
+        TemplateFeature.RABBITMQ,
+        TemplateFeature.S3_BUCKET,
+        TemplateFeature.EMAIL,
+    }
+
+    handler.update_swagger(all_features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/db" in result["paths"]
+    assert "/health/message" in result["paths"]
+    assert "/health/bucket" in result["paths"]
+    assert "/health/email" in result["paths"]
+    assert "/" in result["paths"]
+    assert "/ping" in result["paths"]
+
+    assert result["components"] == sample_swagger_data["components"]
+
+
+def test_update_swagger_no_features_selected(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    no_features: set[TemplateFeature] = set()
+
+    handler.update_swagger(no_features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/db" not in result["paths"]
+    assert "/health/message" not in result["paths"]
+    assert "/health/bucket" not in result["paths"]
+    assert "/health/email" not in result["paths"]
+
+    assert "/" in result["paths"]
+    assert "/ping" in result["paths"]
+
+    assert "components" in result
+    assert "schemas" in result["components"]
+
+
+def test_update_swagger_only_postgresql(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.POSTGRESQL}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/db" in result["paths"]
+    assert "/health/message" not in result["paths"]
+    assert "/health/bucket" not in result["paths"]
+    assert "/health/email" not in result["paths"]
+
+    assert "/" in result["paths"]
+    assert "/ping" in result["paths"]
+
+
+def test_update_swagger_only_rabbitmq(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.RABBITMQ}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/message" in result["paths"]
+    assert "/health/db" not in result["paths"]
+    assert "/health/bucket" not in result["paths"]
+    assert "/health/email" not in result["paths"]
+
+
+def test_update_swagger_only_s3_bucket(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.S3_BUCKET}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/bucket" in result["paths"]
+    assert "/health/db" not in result["paths"]
+    assert "/health/message" not in result["paths"]
+    assert "/health/email" not in result["paths"]
+
+
+def test_update_swagger_only_email(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.EMAIL}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/email" in result["paths"]
+    assert "/health/db" not in result["paths"]
+    assert "/health/message" not in result["paths"]
+    assert "/health/bucket" not in result["paths"]
+
+
+def test_update_swagger_multiple_features(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/db" in result["paths"]
+    assert "/health/email" in result["paths"]
+
+    assert "/health/message" not in result["paths"]
+    assert "/health/bucket" not in result["paths"]
+
+
+def test_update_swagger_file_not_exists(tmp_path: Path) -> None:
+    non_existent_file = tmp_path / "does_not_exist.yml"
+    handler = SwaggerHandler(non_existent_file)
+
+    handler.update_swagger({TemplateFeature.POSTGRESQL})
+
+    assert not non_existent_file.exists()
+
+
+def test_update_swagger_missing_paths_key(tmp_path: Path) -> None:
+    api_file = tmp_path / "api.yml"
+    invalid_swagger = {"openapi": "3.1.0", "info": {"title": "Test"}}
+
+    with api_file.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(invalid_swagger, f)
+
+    handler = SwaggerHandler(api_file)
+    handler.update_swagger({TemplateFeature.POSTGRESQL})
+
+    with api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert result == invalid_swagger
+
+
+def test_update_swagger_preserves_order(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.POSTGRESQL, TemplateFeature.S3_BUCKET}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    paths_keys = list(result["paths"].keys())
+    assert paths_keys.index("/") < paths_keys.index("/ping")
+    assert "/health/bucket" in paths_keys
+    assert "/health/db" in paths_keys
+
+
+def test_update_swagger_components_unchanged(
+    temp_api_file: Path, sample_swagger_data: dict[str, Any]
+) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    handler.update_swagger({TemplateFeature.EMAIL})
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert result["components"] == sample_swagger_data["components"]
+    assert "ErrorResponse" in result["components"]["schemas"]
+    assert "DateTime" in result["components"]["schemas"]
+    assert "UUID" in result["components"]["schemas"]
+    assert "Dummy" in result["components"]["schemas"]
+
+
+def test_get_endpoints_to_remove_all_features() -> None:
+    handler = SwaggerHandler(Path("dummy.yml"))
+    all_features = {
+        TemplateFeature.POSTGRESQL,
+        TemplateFeature.RABBITMQ,
+        TemplateFeature.S3_BUCKET,
+        TemplateFeature.EMAIL,
+    }
+
+    endpoints = handler._get_endpoints_to_remove(all_features)
+
+    assert len(endpoints) == 0
+
+
+def test_get_endpoints_to_remove_no_features() -> None:
+    handler = SwaggerHandler(Path("dummy.yml"))
+    no_features: set[TemplateFeature] = set()
+
+    endpoints = handler._get_endpoints_to_remove(no_features)
+
+    assert endpoints == {
+        "/health/db",
+        "/health/message",
+        "/health/bucket",
+        "/health/email",
+    }
+
+
+def test_get_endpoints_to_remove_partial_features() -> None:
+    handler = SwaggerHandler(Path("dummy.yml"))
+    features = {TemplateFeature.POSTGRESQL, TemplateFeature.EMAIL}
+
+    endpoints = handler._get_endpoints_to_remove(features)
+
+    assert endpoints == {"/health/message", "/health/bucket"}
+
+
+def test_forward_compatibility_mysql_feature(temp_api_file: Path) -> None:
+    handler = SwaggerHandler(temp_api_file)
+    features = {TemplateFeature.POSTGRESQL}
+
+    handler.update_swagger(features)
+
+    with temp_api_file.open("r", encoding="utf-8") as f:
+        result = yaml.safe_load(f)
+
+    assert "/health/db" in result["paths"]


### PR DESCRIPTION
### Problem:
We forgot to handle the fact that the OpenApi documentation located at [`doc/api.yaml`](https://github.com/Abega1642/ar-infra-template/blob/main/doc/api.yaml) should changes according to the selected feature.
### Solution:
We introduce `SwaggerHandler` that removes unused OpenApi specification releated to the non-selected feature