### PR TITLE
Update template clone to take into account the template version

### DIFF
--- a/src/ar_infra/infrastructure/template/github_template_fetcher.py
+++ b/src/ar_infra/infrastructure/template/github_template_fetcher.py
@@ -21,6 +21,7 @@ from src.ar_infra.infrastructure.template.exception import (
     TemplateFetchError,
 )
 from src.ar_infra.logger import get_logger
+from src.ar_infra.properties import TEMPLATE_VERSION
 
 
 log = get_logger()
@@ -65,7 +66,7 @@ class GitHubTemplateFetcher:
             temp_dir = self._create_temp_directory()
             log.info("Cloning to temporary directory: %s", temp_dir)
 
-            self._clone_repository(url, temp_dir)
+            self._clone_repository(url, temp_dir, TEMPLATE_VERSION)
             self._process_template(temp_dir)
 
             log.info("Template validated, moving to destination...")
@@ -116,12 +117,23 @@ class GitHubTemplateFetcher:
             )
             raise TemplateFetchError(f"Failed to move template to destination: {e}") from e
 
-    def _clone_repository(self, url: str, destination: Path) -> None:
+    def _clone_repository(self, url: str, destination: Path, tag: str | None = None) -> None:
         log.info("Starting git clone (this may take a moment)...")
 
         try:
-            git.Repo.clone_from(url, str(destination), depth=1)
+            if tag and self._tag_exists_in_remote(url, tag):
+                log.info("Fetching ar-infra-template version = %s", tag)
+                git.Repo.clone_from(url, str(destination), branch=tag, depth=1)
+            else:
+                if tag:
+                    log.warning(
+                        "Tag '%s' not found in remote repository, cloning default branch instead",
+                        tag,
+                    )
+                git.Repo.clone_from(url, str(destination), depth=1)
+
             log.info("Clone completed successfully")
+
             self._wait_for_git_locks()
 
         except git.exc.GitCommandError as e:
@@ -129,6 +141,26 @@ class GitHubTemplateFetcher:
 
         except (OSError, RuntimeError) as e:
             self._handle_unexpected_error(url, e)
+
+    @staticmethod
+    def _tag_exists_in_remote(url: str, tag: str) -> bool:
+        try:
+            log.info("Checking if tag '%s' exists in remote repository...", tag)
+
+            result = git.cmd.Git().ls_remote("--tags", url, tag)
+            exists = bool(result.strip())
+
+            if exists:
+                log.info("Tag '%s' found in remote repository", tag)
+            else:
+                log.info("Tag '%s' not found in remote repository", tag)
+
+        except git.exc.GitCommandError as e:
+            log.warning("Failed to check remote tags: %s", e)
+            # If we can't check, assume tag doesn't exist and fall back to default branch
+            return False
+
+        return exists
 
     @staticmethod
     def _wait_for_git_locks() -> None:

--- a/src/ar_infra/properties.py
+++ b/src/ar_infra/properties.py
@@ -1,3 +1,4 @@
 """Ar-infra cli properties."""
 
 CLI_VERSION = "0.1.3"
+TEMPLATE_VERSION = "v0.1.0"

--- a/tests/unit/infrastructure/test_github_template_fetcher.py
+++ b/tests/unit/infrastructure/test_github_template_fetcher.py
@@ -15,6 +15,7 @@ from src.ar_infra.infrastructure.template.exception import (
 from src.ar_infra.infrastructure.template.github_template_fetcher import (
     GitHubTemplateFetcher,
 )
+from src.ar_infra.properties import TEMPLATE_VERSION
 
 
 @pytest.fixture
@@ -38,12 +39,16 @@ def valid_template_structure(tmp_path: Path) -> Path:
 
 
 class TestFetchTemplate:
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
-    def test_fetch_template_from_github(
+    def test_fetch_template_from_github_with_tag(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
         valid_template_structure: Path,
@@ -53,6 +58,42 @@ class TestFetchTemplate:
         temp_dir = tmp_path / "temp_clone"
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
+
+        def mock_clone_side_effect(url: str, dest: str, branch: str, depth: int) -> None:
+            shutil.copytree(valid_template_structure, dest)
+
+        mock_clone.side_effect = mock_clone_side_effect
+
+        result = fetcher.fetch(url, destination)
+
+        assert result == "com.example.arinfra"
+        assert destination.exists()
+        assert (destination / "build.gradle").exists()
+        mock_tag_exists.assert_called_once_with(url, TEMPLATE_VERSION)
+        mock_clone.assert_called_once_with(url, str(temp_dir), branch=TEMPLATE_VERSION, depth=1)
+
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
+    @patch("git.Repo.clone_from")
+    @patch("tempfile.mkdtemp")
+    def test_fetch_template_falls_back_when_tag_not_found(
+        self,
+        mock_mkdtemp: Mock,
+        mock_clone: Mock,
+        mock_tag_exists: Mock,
+        fetcher: GitHubTemplateFetcher,
+        tmp_path: Path,
+        valid_template_structure: Path,
+    ) -> None:
+        """Should fall back to default branch when tag doesn't exist."""
+        url = "https://github.com/user/ar-infra.git"
+        destination = tmp_path / "template"
+        temp_dir = tmp_path / "temp_clone"
+
+        mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = False
 
         def mock_clone_side_effect(url: str, dest: str, depth: int) -> None:
             shutil.copytree(valid_template_structure, dest)
@@ -63,7 +104,8 @@ class TestFetchTemplate:
 
         assert result == "com.example.arinfra"
         assert destination.exists()
-        assert (destination / "build.gradle").exists()
+        mock_tag_exists.assert_called_once_with(url, TEMPLATE_VERSION)
+        # Should clone without branch parameter when tag doesn't exist
         mock_clone.assert_called_once_with(url, str(temp_dir), depth=1)
 
     @patch("git.Repo.clone_from")
@@ -83,12 +125,16 @@ class TestFetchTemplate:
         assert result == "com.example.arinfra"
         mock_clone.assert_not_called()
 
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
     def test_force_refetch_ignores_cache(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
         valid_template_structure: Path,
@@ -101,8 +147,9 @@ class TestFetchTemplate:
         shutil.copytree(valid_template_structure, destination)
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
 
-        def mock_clone_side_effect(url: str, dest: str, depth: int) -> None:
+        def mock_clone_side_effect(url: str, dest: str, branch: str, depth: int) -> None:
             shutil.copytree(valid_template_structure, dest)
 
         mock_clone.side_effect = mock_clone_side_effect
@@ -112,12 +159,16 @@ class TestFetchTemplate:
         assert result == "com.example.arinfra"
         mock_clone.assert_called_once()
 
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
     def test_cleanup_temp_dir_on_clone_error(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
     ) -> None:
@@ -128,6 +179,7 @@ class TestFetchTemplate:
         temp_dir.mkdir()
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
         mock_clone.side_effect = OSError("Clone failed")
 
         with pytest.raises(TemplateFetchError):
@@ -136,12 +188,16 @@ class TestFetchTemplate:
         assert not temp_dir.exists()
         assert not destination.exists()
 
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
     def test_cleanup_temp_dir_on_validation_error(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
     ) -> None:
@@ -150,9 +206,9 @@ class TestFetchTemplate:
         temp_dir = tmp_path / "temp_clone"
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
 
-        def mock_clone_invalid(url: str, dest: str, depth: int) -> None:
-            # Create invalid template (missing build.gradle)
+        def mock_clone_invalid(url: str, dest: str, branch: str, depth: int) -> None:
             Path(dest).mkdir(parents=True, exist_ok=True)
             (Path(dest) / "src" / "main" / "java").mkdir(parents=True)
 
@@ -163,6 +219,47 @@ class TestFetchTemplate:
 
         assert not temp_dir.exists()
         assert not destination.exists()
+
+
+class TestTagExistsCheck:
+    @patch("git.cmd.Git")
+    def test_tag_exists_in_remote_returns_true_when_tag_found(
+        self, mock_git_class: Mock, fetcher: GitHubTemplateFetcher
+    ) -> None:
+        mock_git_instance = Mock()
+        mock_git_class.return_value = mock_git_instance
+        mock_git_instance.ls_remote.return_value = "abc123\trefs/tags/v0.1.0"
+
+        result = fetcher._tag_exists_in_remote("https://github.com/user/repo.git", "v0.1.0")
+
+        assert result is True
+        mock_git_instance.ls_remote.assert_called_once_with(
+            "--tags", "https://github.com/user/repo.git", "v0.1.0"
+        )
+
+    @patch("git.cmd.Git")
+    def test_tag_exists_in_remote_returns_false_when_tag_not_found(
+        self, mock_git_class: Mock, fetcher: GitHubTemplateFetcher
+    ) -> None:
+        mock_git_instance = Mock()
+        mock_git_class.return_value = mock_git_instance
+        mock_git_instance.ls_remote.return_value = ""
+
+        result = fetcher._tag_exists_in_remote("https://github.com/user/repo.git", "v0.1.0")
+
+        assert result is False
+
+    @patch("git.cmd.Git")
+    def test_tag_exists_in_remote_returns_false_on_git_error(
+        self, mock_git_class: Mock, fetcher: GitHubTemplateFetcher
+    ) -> None:
+        mock_git_instance = Mock()
+        mock_git_class.return_value = mock_git_instance
+        mock_git_instance.ls_remote.side_effect = git.exc.GitCommandError("ls-remote", 128)
+
+        result = fetcher._tag_exists_in_remote("https://github.com/user/repo.git", "v0.1.0")
+
+        assert result is False
 
 
 class TestURLValidation:
@@ -264,12 +361,16 @@ class TestPackageDetection:
 
 
 class TestErrorHandling:
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
     def test_provide_helpful_error_for_network_issues(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
     ) -> None:
@@ -278,6 +379,7 @@ class TestErrorHandling:
         temp_dir = tmp_path / "temp_clone"
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
 
         error = git.exc.GitCommandError("clone", 128)
         error.stderr = "fatal: could not resolve host github.com"
@@ -286,12 +388,16 @@ class TestErrorHandling:
         with pytest.raises(TemplateFetchError, match="Network/DNS issue"):
             fetcher.fetch(url, destination)
 
+    @patch(
+        "src.ar_infra.infrastructure.template.github_template_fetcher.GitHubTemplateFetcher._tag_exists_in_remote"
+    )
     @patch("git.Repo.clone_from")
     @patch("tempfile.mkdtemp")
     def test_provide_helpful_error_for_permission_issues(
         self,
         mock_mkdtemp: Mock,
         mock_clone: Mock,
+        mock_tag_exists: Mock,
         fetcher: GitHubTemplateFetcher,
         tmp_path: Path,
     ) -> None:
@@ -300,6 +406,7 @@ class TestErrorHandling:
         temp_dir = tmp_path / "temp_clone"
 
         mock_mkdtemp.return_value = str(temp_dir)
+        mock_tag_exists.return_value = True
 
         error = git.exc.GitCommandError("clone", 128)
         error.stderr = "fatal: permission denied"


### PR DESCRIPTION
### Problem : 
When the `ar-infra-template` is updated, for example, we just added the `MySQL` database to be part of the database choice, the template structure has changed. Which means that the older version of `ar-infra-cli` like `v0.1.1`, `v0.1.2`, `v0.1.3` won't work and even breaks.

### Solution : 
In order to keep _**forward compatibility**_ for each version of ar-infra-cli, we add a tag to specify what version of the `ar-infra-template` corresponds to this version of the `ar-infra-cli`. That way, we can move on changing everything from ar-infra-template for our new future features and every newer version of `ar-infra-cli` will NOT break, and will be always compatible.