### PR TITLE
feat: add --no-feature option in init command

### DIFF
--- a/.shell/project-generation.sh
+++ b/.shell/project-generation.sh
@@ -140,6 +140,7 @@ run_project_generation() {
     --project-version="$VERSION"
     --path=./
     --project-dir="$PROJECT_DIR"
+    --no-feature
     --no-cache
     --skip-github-app
   )

--- a/.shell/test-add-dependency-command.sh
+++ b/.shell/test-add-dependency-command.sh
@@ -47,6 +47,7 @@ run_project_generation() {
     --project-version="$VERSION"
     --path=./
     --project-dir="$PROJECT_DIR"
+    --no-feature
     --no-cache
     --skip-github-app
   )

--- a/src/ar_infra/cli/command/init.py
+++ b/src/ar_infra/cli/command/init.py
@@ -46,6 +46,7 @@ class InitCommandArgs:
     project_dir: str | None
     features: str | None
     no_features: str | None
+    no_feature: bool
     no_cache: bool
     skip_github_app: bool
 
@@ -71,14 +72,20 @@ class InitCommand:
         )
 
         if is_interactive:
-            self._execute_interactive(skip_github_app=args.skip_github_app)
+            self._execute_interactive(
+                skip_github_app=args.skip_github_app, skip_features=args.no_feature
+            )
         else:
             self._execute_cli(args)
 
-    def _execute_interactive(self, *, skip_github_app: bool = False) -> None:
+    def _execute_interactive(
+        self, *, skip_github_app: bool = False, skip_features: bool = False
+    ) -> None:
         Banner.show(wait_for_enter=True)
         try:
-            inputs = self.interactive_prompt.collect_inputs(skip_github_app=skip_github_app)
+            inputs = self.interactive_prompt.collect_inputs(
+                skip_github_app=skip_github_app, skip_features=skip_features
+            )
 
             self._execute_common(
                 group_id=inputs["group_id"],
@@ -86,7 +93,7 @@ class InitCommand:
                 version=inputs["version"],
                 destination=str(inputs["destination"]),
                 project_dir_name=inputs["project_dir_name"],
-                enabled_features=set(inputs["enabled_features"] or []),
+                enabled_features=set(inputs.get("enabled_features") or []),
                 template_url=AR_INFRA_TEMPLATE,
                 use_template_cache=inputs["use_template_cache"],
             )
@@ -125,7 +132,19 @@ class InitCommand:
         assert args.project_dir is not None
 
         try:
-            enabled_features = self._parse_features(args.features, args.no_features)
+            enabled_features = self._parse_features(
+                args.features, args.no_features, no_feature=args.no_feature
+            )
+
+            database_features = {"postgresql", "mysql"}
+            selected_databases = enabled_features & database_features
+
+            if len(selected_databases) > 1:
+                self._abort(
+                    "Only one database can be selected. "
+                    f"You have selected: {', '.join(sorted(selected_databases))}. "
+                    "Please choose either 'postgresql' or 'mysql', not both."
+                )
 
             destination_path = Path(args.path or ".").resolve()
             project_path = destination_path / args.project_dir
@@ -252,7 +271,12 @@ class InitCommand:
     def _parse_features(
         features: str | None,
         no_features: str | None,
+        *,
+        no_feature: bool,
     ) -> set[str]:
+        if no_feature:
+            return set()
+
         all_features = {"postgresql", "mysql", "rabbitmq", "s3_bucket", "email"}
 
         if features is not None:

--- a/src/ar_infra/cli/main.py
+++ b/src/ar_infra/cli/main.py
@@ -66,6 +66,9 @@ def _show_help_and_exit(
 @click.option("--project-dir", type=str, help=PROJECT_DIR_OPTION_HELP)
 @click.option("--features", type=str, help=FEATURES_OPTION_HELP)
 @click.option("--disable-features", type=str, help=NO_FEATURES_OPTION_HELP)
+@click.option(
+    "--no-feature", "no_feature", is_flag=True, help="Generate project without any features"
+)
 @click.option("--no-cache", "no_cache", is_flag=True, help=NO_CACHE_OPTION_HELP)
 @click.option(
     "--skip-github-app",
@@ -91,6 +94,7 @@ def init(
     features: str | None,
     disable_features: str | None,
     *,
+    no_feature: bool,
     no_cache: bool,
     skip_github_app: bool,
 ) -> None:
@@ -103,6 +107,7 @@ def init(
         project_dir=project_dir,
         features=features,
         no_features=disable_features,
+        no_feature=no_feature,
         no_cache=no_cache,
         skip_github_app=skip_github_app,
     )

--- a/src/ar_infra/cli/prompt/interactive_prompt.py
+++ b/src/ar_infra/cli/prompt/interactive_prompt.py
@@ -28,9 +28,11 @@ class InteractivePrompt:
         self.security_validator = PathSecurityValidator()
         self.github_app_handler = GitHubAppHandler()
 
-    def collect_inputs(self, *, skip_github_app: bool = False) -> dict[str, Any]:
+    def collect_inputs(
+        self, *, skip_github_app: bool = False, skip_features: bool = False
+    ) -> dict[str, Any]:
         while True:
-            inputs = self._collect_all_prompts()
+            inputs = self._collect_all_prompts(skip_features=skip_features)
 
             if self._confirm_and_proceed(inputs):
                 if not skip_github_app:
@@ -55,7 +57,7 @@ class InteractivePrompt:
 
             print("\n")
 
-    def _collect_all_prompts(self) -> dict[str, Any]:
+    def _collect_all_prompts(self, *, skip_features: bool = False) -> dict[str, Any]:
         group_id = self._prompt_group_id()
         artifact_id = self._prompt_artifact_id()
         version = self._prompt_version()
@@ -77,7 +79,8 @@ class InteractivePrompt:
             print("\nOperation cancelled.\n")
             raise KeyboardInterrupt(OPERATION_CANCELLED_ERR_MESSAGE) from None
 
-        features = self._prompt_features()
+        features = [] if skip_features else self._prompt_features()
+
         use_cache = self._prompt_use_cache()
 
         return {

--- a/src/ar_infra/cli/ui/help.py
+++ b/src/ar_infra/cli/ui/help.py
@@ -5,6 +5,18 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
+from src.ar_infra.cli.resources.documentation import (
+    ADD_DEPENDENCY_PROJECT_PATH_HELP,
+    ARTIFACT_OPTION_HELP,
+    FEATURES_OPTION_HELP,
+    GROUP_OPTION_HELP,
+    NO_CACHE_OPTION_HELP,
+    NO_FEATURES_OPTION_HELP,
+    PATH_OPTION_HELP,
+    PROJECT_DIR_OPTION_HELP,
+    SKIP_COMMAND,
+    VERSION_OPTION_HELP,
+)
 from src.ar_infra.properties import AR_INFRA_TEMPLATE
 
 
@@ -151,12 +163,50 @@ def show_init_command_body(console: Console) -> None:
     console.print("[bold yellow]COMMAND LINE MODE:[/bold yellow]")
     console.print(
         Syntax(
-            "ar-infra init --group=com.example --artifact=myapp --project-version=1.0.0",
+            "ar-infra init --group=com.example --artifact=myapp --no-feature",
             "bash",
             theme="monokai",
             background_color="default",
         )
     )
+    console.print()
+
+
+def show_init_options(console: Console) -> None:
+    console.print("[bold yellow]INIT OPTIONS:[/bold yellow]")
+    options_table = Table(show_header=False, box=None, padding=(0, 2))
+    options_table.add_column(style="cyan bold", width=20)
+    options_table.add_column()
+
+    options_table.add_row("--group", GROUP_OPTION_HELP.strip())
+    options_table.add_row("--artifact", ARTIFACT_OPTION_HELP.strip())
+    options_table.add_row("--project-version", VERSION_OPTION_HELP.strip())
+    options_table.add_row("--path", PATH_OPTION_HELP.strip())
+    options_table.add_row("--project-dir", PROJECT_DIR_OPTION_HELP.strip())
+    options_table.add_row("--features", FEATURES_OPTION_HELP.strip())
+    options_table.add_row("--disable-features", NO_FEATURES_OPTION_HELP.strip())
+    options_table.add_row("--no-feature", "Generate project without any features")
+    options_table.add_row("--no-cache", NO_CACHE_OPTION_HELP.strip())
+    options_table.add_row("--skip-github-app", SKIP_COMMAND.strip())
+
+    console.print(options_table)
+    console.print()
+
+
+def show_add_deps_options(console: Console) -> None:
+    console.print("[bold yellow]ADD-DEPENDENCY OPTIONS:[/bold yellow]")
+    options_table = Table(show_header=False, box=None, padding=(0, 2))
+    options_table.add_column(style="cyan bold", width=20)
+    options_table.add_column()
+
+    options_table.add_row(
+        "DEPENDENCIES...", "One or more Gradle dependency strings to add (required)."
+    )
+
+    options_table.add_row("--project-path", ADD_DEPENDENCY_PROJECT_PATH_HELP.strip())
+    options_table.add_row("--help, -h", "Show this message and exit.")
+
+    console.print(options_table)
     console.print()
 
 
@@ -173,7 +223,9 @@ def show_help() -> None:
     console.print("    ar-infra init [OPTIONS]")
 
     show_add_deps_header(console)
+    show_add_deps_options(console)
     show_init_command_body(console)
+    show_init_options(console)
     show_init_command_example(console)
     show_add_deps_body(console)
     show_feature_list(console)


### PR DESCRIPTION
### Problem : 
When user wants to generate a brand new project from `ar-infra-cli` with no feature at all they user must user `--disable-features` and list all features they don't want to use. Problem is that suppose the template grows and we have 15 features. This means the user is going to list all 15 features to be able to generate a project without any features.

### Solution : 
We introduce `--no-feature` option to generate a project without any feature at all.